### PR TITLE
Ensure output messages are LIS2-A2 compliant

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+
+1.0.0 (unreleased)
+------------------
+
+- #1 Ensure output messages are LIS2-A2 compliant

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -188,7 +188,8 @@ class ASTMProtocol(asyncio.Protocol):
         # validate message if any
         if full_message is not None:
             self.validate_checksum(full_message)
-            self.messages.append(full_message)
+            # remove frame number and checksum from the final message
+            self.messages.append(message[1:-2])
 
     def validate_checksum(self, message):
         frame_cs = message[1:-2]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the message the server ends up with, after a successful ASTM conversation with a sender, is LIS2-A2 compliant as well. This is, the message does not contain any (LIS1-A) protocol-specific characters and elements, and FN (frame number) and checksum verification code in particular. 

This is is the message that is either stored in the filesystem or/and sent to SENAITE by means of a push consumer, so it must be LIS2-A2 compliant

## Current behavior before PR

Given the following LIS2-A2 compliant message:

```
H|\^&|9||cobas infinity ^Roche Diagnostics^^3.03.12|||||cobas infinity ^Roche Diagnostics||P||20221021184225
P|1||||||||||||||||||||||20221013093955
O|1|221000044W|^^221000044|^^^77140-2\^^^1996-8\^^^59570-2|R|20221013093955|||||X||||SER||||||0||||F
R|1|^^SCRE2^77140-2|44|µmol / l|[44.2 - 132]|||F||||20221021184219
R|2|^^S-CA2^1996-8|4|mmol / l|[2.2 - 2.7]|||F||||20221021184219
R|3|^^UREAL^59570-2|5|mmol / l|[3.5 - 7.1]|||F||||20221021184218
L|1|N
```

The following LIS1-A conversation takes place:

```
Establishment phase ...
-> <ENQ>
<- <ACK>
Transfer phase ...
-> <STX>1H|\^&|9||cobas infinity ^Roche Diagnostics^^3.03.12|||||cobas infinity ^Roche Diagnostics||P||20221021184225<ETX>34<CR><LF>
<- <ACK>
-> <STX>2P|1||||||||||||||||||||||20221013093955<ETX>A4<CR><LF>
<- <ACK>
-> <STX>3O|1|221000044W|^^221000044|^^^77140-2\^^^1996-8\^^^59570-2|R|20221013093955|||||X||||SER||||||0||||F<ETX>42<CR><LF>
<- <ACK>
-> <STX>4R|1|^^SCRE2^77140-2|44|µmol / l|[44.2 - 132]|||F||||20221021184219<ETX>F3<CR><LF>
<- <ACK>
-> <STX>5R|2|^^S-CA2^1996-8|4|mmol / l|[2.2 - 2.7]|||F||||20221021184219<ETX>35<CR><LF>
<- <ACK>
-> <STX>6R|3|^^UREAL^59570-2|5|mmol / l|[3.5 - 7.1]|||F||||20221021184218<ETX>A8<CR><LF>
<- <ACK>
-> <STX>7L|1|N<ETX>FD<CR><LF>
<- <ACK>
Termination phase ...
-> <EOT>
```

As a result, the following **non-LIS2-A2-compliant message** is stored in the filesystem or/and sent to SENAITE via push (note the fn at the beginning of each record, as well as the checksum at the end):

```
1H|\^&|9||cobas infinity ^Roche Diagnostics^^3.03.12|||||cobas infinity ^Roche Diagnostics||P||2022102118422534
2P|1||||||||||||||||||||||20221013093955A4
3O|1|221000044W|^^221000044|^^^77140-2\^^^1996-8\^^^59570-2|R|20221013093955|||||X||||SER||||||0||||F42
4R|1|^^SCRE2^77140-2|44|µmol / l|[44.2 - 132]|||F||||20221021184219F3
5R|2|^^S-CA2^1996-8|4|mmol / l|[2.2 - 2.7]|||F||||2022102118421935
6R|3|^^UREAL^59570-2|5|mmol / l|[3.5 - 7.1]|||F||||20221021184218A8
7L|1|NFD
```

## Desired behavior after PR is merged

As a result, the following **LIS2-A2-compliant message** is stored in the filesystem or/and sent to SENAITE via push, that is an exact copy of the message initially sent, without control characters:

```
H|\^&|9||cobas infinity ^Roche Diagnostics^^3.03.12|||||cobas infinity ^Roche Diagnostics||P||20221021184225
P|1||||||||||||||||||||||20221013093955
O|1|221000044W|^^221000044|^^^77140-2\^^^1996-8\^^^59570-2|R|20221013093955|||||X||||SER||||||0||||F
R|1|^^SCRE2^77140-2|44|µmol / l|[44.2 - 132]|||F||||20221021184219
R|2|^^S-CA2^1996-8|4|mmol / l|[2.2 - 2.7]|||F||||20221021184219
R|3|^^UREAL^59570-2|5|mmol / l|[3.5 - 7.1]|||F||||20221021184218
L|1|N
```


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html