### PR TITLE
Allow to store the raw ASTM messages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #5 Allow to store the raw ASTM messages
 - #4 Improve ASTM Protocol for Multi connections
 - #3 Fix ASTM message splitting and added tests
 - #1 Ensure output messages are LIS2-A2 compliant

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -227,9 +227,34 @@ class ASTMProtocol(asyncio.Protocol):
         else:
             full_message = message
 
-        if full_message is not None:
-            seq, msg, cs = self.split_message(full_message)
-            self.messages.append(msg)
+        # message not yet complete
+        if not full_message:
+            return
+
+        # append the raw message to the messages
+        # NOTE: Conversion to LIS2-A2 format is done when EOT is received
+        if self.validate_checksum(full_message):
+            self.messages.append(full_message)
+
+    def validate_checksum(self, message):
+        """Validate the checksum of the message
+
+        :param message: The received message (line) of the instrument
+                        containing the STX at the beginning and the cecksum at
+                        the end.
+        :returns: True if the received message is valid or otherwise it raises
+                  a NotAccepted Exception.
+        """
+        # get the frame w/o STX and checksum
+        frame = message[1:-2]
+        # check if the checksum matches
+        cs = message[-2:]
+        # generate the checksum for the frame
+        ccs = make_checksum(frame)
+        if cs != ccs:
+            raise NotAccepted(
+                "Checksum failure: expected %r, calculated %r" % (cs, ccs))
+        return True
 
     def split_message(self, message):
         """Split the message into seqence, message and checksum
@@ -238,11 +263,6 @@ class ASTMProtocol(asyncio.Protocol):
         frame = message[1:-2]
         # Get the checksum
         cs = message[-2:]
-        # validate the checksum
-        ccs = make_checksum(frame)
-        if cs != ccs:
-            raise NotAccepted(
-                "Checksum failure: expected %r, calculated %r" % (cs, ccs))
         # Get the sequence
         seq = frame[:1]
         if not seq.isdigit():

--- a/src/senaite/astm/server.py
+++ b/src/senaite/astm/server.py
@@ -6,12 +6,12 @@ import contextlib
 import logging
 import os
 import sys
-from datetime import datetime
 
 from senaite.astm import lims
 from senaite.astm import logger
 from senaite.astm.lims import post_to_senaite
 from senaite.astm.protocol import ASTMProtocol
+from senaite.astm.utils import write_message
 
 LOGFILE = "senaite-astm-server.log"
 
@@ -23,16 +23,6 @@ async def consume(queue, callback=None):
         message = await queue.get()
         if callable(callback):
             callback(message)
-
-
-def write_message(message, path, ext=".txt"):
-    """Write ASTM Message to file
-    """
-    now = datetime.now()
-    timestamp = now.strftime("%Y-%m-%d_%H:%M:%S")
-    filename = "{}{}".format(timestamp, ext)
-    with open(os.path.join(path, filename), "wb") as f:
-        f.write(message)
 
 
 def main():

--- a/src/senaite/astm/server.py
+++ b/src/senaite/astm/server.py
@@ -52,7 +52,7 @@ def main():
         '-o',
         '--output',
         type=str,
-        help='Output directory to write ASTM files')
+        help='Output directory to write full messages')
 
     lims_group.add_argument(
         '-u',
@@ -67,6 +67,13 @@ def main():
         type=str,
         default='senaite.lis2a.import',
         help='SENAITE push consumer interface')
+
+    lims_group.add_argument(
+        '-m',
+        '--message-format',
+        type=str,
+        default='lis2a',
+        help='Message format to send to SENAITE. Supports "astm" or "lis2a".')
 
     lims_group.add_argument(
         '-r',
@@ -156,7 +163,7 @@ def main():
                     post_to_senaite, message, session, **session_args))
 
     # Create a TCP server coroutine listening on port of the host address.
-    protocol = ASTMProtocol()
+    protocol = ASTMProtocol(message_format=args.message_format)
     server_coro = loop.create_server(
         lambda: protocol, host=args.listen, port=args.port)
 

--- a/src/senaite/astm/utils.py
+++ b/src/senaite/astm/utils.py
@@ -1,11 +1,28 @@
 # -*- coding: utf-8 -*-
 
+import os
 import time
+from datetime import datetime
+from pathlib import Path
 
 from senaite.astm.constants import CRLF
 from senaite.astm.constants import ETB
 from senaite.astm.constants import ETX
 from senaite.astm.constants import STX
+
+
+def write_message(message, path, dateformat="%Y-%m-%d_%H:%M:%S", ext=".txt"):
+    """Write ASTM Message to file
+    """
+    path = Path(path)
+    if not path.exists():
+        # ensure the directory exists
+        path.mkdir(parents=True, exist_ok=True)
+    now = datetime.now()
+    timestamp = now.strftime(dateformat)
+    filename = "{}{}".format(timestamp, ext)
+    with open(os.path.join(path, filename), "wb") as f:
+        f.write(message)
 
 
 def is_chunked_message(message):


### PR DESCRIPTION
## Description

**☝️ Please merge #4 first**

This PR allows to keep the raw (non-LIS2A compliant) messages for debugging purposes.

The ASTM message is only stored if the folder `astm_messages` exists in the current working directory!