### PR TITLE
Handle empty messages on EOT and fix checksum validation

### DIFF
--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -163,6 +163,14 @@ class ASTMProtocol(asyncio.Protocol):
         # stop any running timer
         self.cancel_timer()
 
+        # XXX: Seen by Yumizen instrument that EOT is sent right after ENQ.
+        #      Maybe this is some kind of keepalive?
+        #      -> For now we cancel the automatic timeout and reset the
+        #         transfer state to allow further ENQs to be sent.
+        if not self.messages:
+            self.in_transfer_state = False
+            return
+
         # LIS-2A compliant message
         lis2a_message = b""
         # Raw ASTM message (including STX, sequence and checksum)

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -5,6 +5,7 @@ import os
 
 from senaite.astm import logger
 from senaite.astm.constants import ACK
+from senaite.astm.constants import CRLF
 from senaite.astm.constants import ENQ
 from senaite.astm.constants import EOT
 from senaite.astm.constants import NAK
@@ -258,6 +259,8 @@ class ASTMProtocol(asyncio.Protocol):
         :returns: True if the received message is valid or otherwise it raises
                   a NotAccepted Exception.
         """
+        # remove any trailing newlines at the end of the message
+        message = message.rstrip(CRLF)
         # get the frame w/o STX and checksum
         frame = message[1:-2]
         # check if the checksum matches
@@ -272,6 +275,8 @@ class ASTMProtocol(asyncio.Protocol):
     def split_message(self, message):
         """Split the message into seqence, message and checksum
         """
+        # remove any trailing newlines at the end of the message
+        message = message.rstrip(CRLF)
         # Remove the STX at the beginning and the checksum at the end
         frame = message[1:-2]
         # Get the checksum

--- a/src/senaite/astm/tests/base.py
+++ b/src/senaite/astm/tests/base.py
@@ -6,7 +6,6 @@ from glob import glob
 from unittest import IsolatedAsyncioTestCase
 
 from senaite.astm.constants import ACK
-from senaite.astm.constants import CRLF
 from senaite.astm.constants import ENQ
 
 
@@ -58,9 +57,7 @@ class ASTMTestBase(IsolatedAsyncioTestCase):
 
         # Send instrument data
         for line in data:
-            # Test fixture: Remove trailing \r\n
-            message = line.strip(CRLF)
-            writer.write(message)
+            writer.write(line)
             await writer.drain()
             response = await reader.read(100)
             # We expect an ACK as response


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR handles empty messages received on EOT.
Furthermore, it ensures that trailing CR LF is removed when message is splitted/validated.

## Current behavior before PR

- Empty messages are processed in EOT and resulted in empty logged files
- CR LF caused checksum validation to fail

## Desired behavior after PR is merged

- Empty messages in EOT are not processed
- CR LF is ignored for checksum generation / message splitting
- 
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
