### PR TITLE
Fix hanging ENQ

### DIFF
--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -99,14 +99,13 @@ class ASTMProtocol(asyncio.Protocol):
         """
         logger.debug("-> Data received from {!s}: {!r}".format(
             self.client, data))
+        # restart the timer when data is received
+        self.restart_timer()
         # handle the data
         response = self.handle_data(data)
         if response is not None:
             logger.debug("<- Sending response: {!r}".format(response))
             self.transport.write(response)
-            # restart the timer
-            # -> this ensures the next data is received within the timeout
-            self.restart_timer()
 
     def handle_data(self, data):
         """Process incoming data

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -166,10 +166,9 @@ class ASTMProtocol(asyncio.Protocol):
 
         # XXX: Seen by Yumizen instrument that EOT is sent right after ENQ.
         #      Maybe this is some kind of keepalive?
-        #      -> For now we cancel the automatic timeout and reset the
-        #         transfer state to allow further ENQs to be sent.
+        #      For now we flush the session an keep the connection alive
         if not self.messages:
-            self.in_transfer_state = False
+            self.flush_session()
             return
 
         # LIS-2A compliant message

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -122,6 +122,8 @@ class ASTMProtocol(asyncio.Protocol):
             response = self.on_eot(data)
         elif data.startswith(STX):
             response = self.on_message(data)
+        elif self.in_transfer_state:
+            response = self.on_message(data)
         else:
             response = self.default_handler(data)
         return response

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -122,8 +122,6 @@ class ASTMProtocol(asyncio.Protocol):
             response = self.on_eot(data)
         elif data.startswith(STX):
             response = self.on_message(data)
-        elif self.in_transfer_state:
-            response = self.on_message(data)
         else:
             response = self.default_handler(data)
         return response

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -79,7 +79,7 @@ class ASTMProtocol(asyncio.Protocol):
     def close_connection(self):
         """Cleanup and close connection
         """
-        self.discard_env()
+        self.flush_session()
         self.transport.close()
 
     def discard_chunked_messages(self):
@@ -87,7 +87,7 @@ class ASTMProtocol(asyncio.Protocol):
         """
         self.chunks = []
 
-    def discard_env(self):
+    def flush_session(self):
         """Flush environment
         """
         self.chunks = []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where a Yumizen H550 hangs in an `ENQ` loop.

## Current behavior before PR

Instrument sends repeating `ENQ` requests

## Desired behavior after PR is merged

Session is flushed after `EOT` is sent.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
