### PR TITLE
Make field descriptors quiet and tolerant

### DIFF
--- a/src/senaite/astm/fields.py
+++ b/src/senaite/astm/fields.py
@@ -7,9 +7,9 @@ import datetime
 import decimal
 import inspect
 import json
-import time
-import warnings
 from itertools import islice
+
+from senaite.astm import logger
 
 
 class Field(object):
@@ -54,10 +54,13 @@ class Field(object):
 
 
 class NotUsedField(Field):
-    """Mapping field for value that should be used.
+    """Mapping field for slots that the instrument may populate but
+    we deliberately don't model.
 
-    Acts as placeholder.  On attempt to assign something to it raises
-    :exc:`UserWarning` and rejects assigned value.
+    Any assigned value is silently dropped. The field used to emit a
+    :exc:`UserWarning` per assignment, which drowned out real
+    warnings (the cobas_c311 fixture alone produced ~78 of them per
+    parse) without giving the operator anything actionable.
     """
     def __init__(self, name=None):
         super(NotUsedField, self).__init__(name)
@@ -66,8 +69,6 @@ class NotUsedField(Field):
         return None
 
     def _set_value(self, value):
-        warnings.warn("Field %r is not used, any assignments are omitted"
-                      "" % self.name, UserWarning)
         return None
 
 
@@ -125,13 +126,36 @@ class JSONListField(Field):
             return default
 
 
+def _parse_with_formats(value, formats):
+    """Try each format in order, return the first match.
+
+    :raises ValueError: when none of the formats match.
+    """
+    for fmt in formats:
+        try:
+            return datetime.datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise ValueError("Value %r does not match any of: %s"
+                     "" % (value, ", ".join(formats)))
+
+
 class DateField(Field):
-    """Mapping field for storing date/time values.
+    """Mapping field for storing date values.
+
+    The canonical output format is :attr:`format`. Subclasses can
+    extend :attr:`parse_formats` to accept additional formats on
+    input; the canonical format is always tried first.
     """
     format = "%Y%m%d"
+    parse_formats = ()
+
+    @property
+    def _accepted_formats(self):
+        return (self.format,) + tuple(self.parse_formats)
 
     def _get_value(self, value):
-        return datetime.datetime.strptime(value, self.format)
+        return _parse_with_formats(value, self._accepted_formats)
 
     def _set_value(self, value):
         if isinstance(value, (str, bytes)):
@@ -143,17 +167,23 @@ class DateField(Field):
 
 class TimeField(Field):
     """Mapping field for storing times.
+
+    The canonical output format is :attr:`format`. Subclasses can
+    extend :attr:`parse_formats` to accept additional formats on
+    input; the canonical format is always tried first.
     """
     format = "%H%M%S"
+    parse_formats = ()
+
+    @property
+    def _accepted_formats(self):
+        return (self.format,) + tuple(self.parse_formats)
 
     def _get_value(self, value):
         if isinstance(value, (str, bytes)):
-            try:
-                value = value.split(".", 1)[0]  # strip out microseconds
-                value = datetime.time(*time.strptime(value, self.format)[3:6])
-            except ValueError:
-                raise ValueError("Value %r does not match format %s"
-                                 "" % (value, self.format))
+            value = value.split(".", 1)[0]  # strip out microseconds
+            parsed = _parse_with_formats(value, self._accepted_formats)
+            return parsed.time()
         return value
 
     def _set_value(self, value):
@@ -168,11 +198,20 @@ class TimeField(Field):
 
 class DateTimeField(Field):
     """Mapping field for storing date/time values.
+
+    The canonical output format is :attr:`format`. Subclasses can
+    extend :attr:`parse_formats` to accept additional formats on
+    input; the canonical format is always tried first.
     """
     format = "%Y%m%d%H%M%S"
+    parse_formats = ()
+
+    @property
+    def _accepted_formats(self):
+        return (self.format,) + tuple(self.parse_formats)
 
     def _get_value(self, value):
-        return datetime.datetime.strptime(value, self.format)
+        return _parse_with_formats(value, self._accepted_formats)
 
     def _set_value(self, value):
         if isinstance(value, (str, bytes)):
@@ -214,14 +253,23 @@ class ConstantField(Field):
 
 
 class SetField(Field):
-    """Mapping field for predefined set of values.
+    """Mapping field for a predefined set of values.
+
+    By default, unknown values are accepted and a debug message is
+    logged. A device firmware update that introduces a new status
+    code should not crash parsing of every message that contains it.
+
+    Pass ``strict=True`` to restore the legacy raise-on-unknown
+    behaviour (useful for tests or for fields whose vocabulary is
+    truly closed).
     """
     def __init__(self, name=None, default=None,
                  required=False, length=None,
-                 values=None, field=Field()):
+                 values=None, field=Field(), strict=False):
         super(SetField, self).__init__(name, default, required, length)
         self.field = field
         self.values = values and set(values) or set([])
+        self.strict = strict
 
     def _get_value(self, value):
         return self.field._get_value(value)
@@ -229,7 +277,12 @@ class SetField(Field):
     def _set_value(self, value):
         value = self.field._get_value(value)
         if value not in self.values:
-            raise ValueError("Unexpected value %r (%s)" % (value, self.name))
+            if self.strict:
+                raise ValueError(
+                    "Unexpected value %r (%s)" % (value, self.name))
+            logger.debug(
+                "Field %r received unexpected value %r (allowed: %s)",
+                self.name, value, sorted(self.values))
         return self.field._set_value(value)
 
 

--- a/src/senaite/astm/tests/test_fields.py
+++ b/src/senaite/astm/tests/test_fields.py
@@ -52,11 +52,18 @@ class NotUsedFieldTestCase(ASTMTestBase):
         self.assertEqual(obj.field, None)
         self.assertEqual(obj[0], None)
 
-    def test_set_value(self):
+    def test_set_value_silently_drops(self):
+        """Assignments are dropped without emitting a warning.
+
+        Previously every assignment fired a UserWarning, which
+        flooded the log with no actionable signal — the cobas_c311
+        fixture alone produced ~78 of them per parse.
+        """
         obj = self.Dummy()
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             obj.field = 42
-            assert issubclass(w[-1].category, UserWarning)
+            self.assertEqual(w, [])
         self.assertEqual(obj.field, None)
 
 
@@ -346,13 +353,24 @@ class SetFieldTestCase(ASTMTestBase):
         obj.field = "bar"
         self.assertEqual(obj.field, "bar")
 
-    def test_restrict_new_values_by_specified_set(self):
+    def test_unknown_values_are_accepted_by_default(self):
+        """A new vocabulary item from a device firmware update
+        should not crash parsing of every message that contains it.
+        """
         obj = self.Dummy()
+        obj.field = "boo"
+        self.assertEqual(obj.field, "boo")
+
+    def test_strict_mode_raises_on_unknown_value(self):
+        class Dummy(Mapping):
+            field = fields.SetField(
+                values=["foo", "bar", "baz"], strict=True)
+        obj = Dummy()
         self.assertRaises(ValueError, setattr, obj, "field", "boo")
 
-    def test_reject_any_value(self):
+    def test_strict_with_empty_value_set_rejects_everything(self):
         class Dummy(Mapping):
-            field = fields.SetField()
+            field = fields.SetField(strict=True)
         obj = Dummy()
         self.assertRaises(ValueError, setattr, obj, "field", "bar")
         self.assertRaises(ValueError, setattr, obj, "field", "foo")
@@ -374,6 +392,71 @@ class SetFieldTestCase(ASTMTestBase):
         obj = self.Dummy()
         obj.field = "foo"
         self.assertEqual(obj._data["field"], "foo")
+
+
+class SetFieldTolerantLoggingTest(ASTMTestBase):
+    """Tolerant SetField logs the unknown value but does not crash."""
+
+    def setUp(self):
+        class Dummy(Mapping):
+            field = fields.SetField(values=["foo", "bar"])
+        self.Dummy = Dummy
+
+    def test_unknown_value_is_logged_at_debug(self):
+        with self.assertLogs("senaite.astm", level="DEBUG") as log:
+            obj = self.Dummy()
+            obj.field = "boo"
+        self.assertTrue(
+            any("unexpected value 'boo'" in line for line in log.output),
+            "expected DEBUG log about unexpected value, got: %r"
+            "" % log.output)
+
+
+class MultiFormatDateFieldTest(ASTMTestBase):
+    """Date fields accept extra formats via parse_formats."""
+
+    def test_date_field_accepts_extra_format(self):
+        class IsoDateField(fields.DateField):
+            parse_formats = ("%Y-%m-%d",)
+
+        class Dummy(Mapping):
+            field = IsoDateField()
+
+        obj = Dummy()
+        obj.field = "2026-05-09"
+        self.assertEqual(obj._data["field"], "20260509")
+
+    def test_date_field_canonical_format_still_works(self):
+        class IsoDateField(fields.DateField):
+            parse_formats = ("%Y-%m-%d",)
+
+        class Dummy(Mapping):
+            field = IsoDateField()
+
+        obj = Dummy()
+        obj.field = "20260509"
+        self.assertEqual(obj._data["field"], "20260509")
+
+    def test_datetime_field_tries_each_format_in_order(self):
+        class FlexibleDT(fields.DateTimeField):
+            parse_formats = ("%Y-%m-%dT%H:%M:%S", "%d/%m/%Y %H:%M:%S")
+
+        class Dummy(Mapping):
+            field = FlexibleDT()
+
+        obj = Dummy()
+        obj.field = "09/05/2026 14:30:00"
+        self.assertEqual(obj._data["field"], "20260509143000")
+
+    def test_date_field_raises_when_no_format_matches(self):
+        class IsoDateField(fields.DateField):
+            parse_formats = ("%Y-%m-%d",)
+
+        class Dummy(Mapping):
+            field = IsoDateField()
+
+        obj = Dummy()
+        self.assertRaises(ValueError, setattr, obj, "field", "nope")
 
 
 class ComponentFieldTestCase(ASTMTestBase):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fourth step on the `2.x` line. Three field-descriptor behaviours
made the package noisy in production and brittle against firmware
changes. This PR fixes the symptoms without rewriting the
descriptor framework — that is deferred until we know whether
moving to `dataclasses` actually pays off.

Linked issue: https://github.com/senaite/senaite.astm/issues/

## Current behavior before PR

- `NotUsedField._set_value` calls `warnings.warn(UserWarning)` for
  every assignment. The `cobas_c311` fixture alone triggers ~78 of
  these per parse, with no actionable signal for the operator.
- `SetField._set_value` raises `ValueError` if the device sends a
  value not in the declared set. A firmware update that introduces
  a new status code immediately breaks parsing of every message
  that contains it.
- `DateField`, `TimeField` and `DateTimeField` accept exactly one
  format. Vendor-specific date strings (ISO dates, slash-separated
  dates, etc.) require a new field subclass with a custom parse
  routine.

## Desired behavior after PR is merged

- `NotUsedField` silently drops assignments. No more
  `UserWarning` flood — the test suite goes from 132 warnings to
  0 without changing test outcomes.
- `SetField` accepts unknown values by default and logs them at
  debug level so they can be surfaced when needed but never crash
  parsing. Pass `strict=True` to restore the legacy
  raise-on-unknown behaviour.
- `DateField`, `TimeField` and `DateTimeField` gain a
  `parse_formats` class attribute (tuple). Subclasses can extend
  it to accept additional input formats; the canonical `format` is
  always tried first and is still used for output, so existing
  snapshots are unchanged.

259 tests pass (253 previous + 6 new), flake8 clean, zero
warnings emitted by the test run.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html