### PR TITLE
Introduce the instrument registry (PR-E1)

### DIFF
--- a/src/senaite/astm/core/instrument.py
+++ b/src/senaite/astm/core/instrument.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Instrument registry.
+
+A single mechanism for describing a supported analyzer:
+
+- a human-readable :attr:`name` (also used as the registry key),
+- a :attr:`header_regex` matched against the first ASTM message to
+  identify the device,
+- a :attr:`record_map` mapping record type characters (H, P, O, R, ...)
+  to the typed record class used to parse them,
+- optional :meth:`preparse` and :meth:`get_metadata` hooks.
+
+Instruments register themselves at import time via the
+:func:`register_instrument` decorator. :func:`find_instrument`
+resolves an instrument from a raw header line; overlapping regexes
+raise :class:`AmbiguousInstrumentError` rather than silently picking
+one match.
+
+PR-E1 introduces the mechanism without migrating any instrument.
+PR-E2 will move every instrument to this registry and remove the
+legacy ``pkgutil``-based discovery in :mod:`senaite.astm.wrapper`.
+"""
+
+import re
+
+from senaite.astm import logger
+
+
+class AmbiguousInstrumentError(LookupError):
+    """Raised when more than one registered instrument matches the
+    same header. The caller must rename or tighten one of the
+    regexes; falling back to "first match wins" hides bugs.
+    """
+
+
+class Instrument(object):
+    """Base class for registered instruments.
+
+    Subclasses set :attr:`name`, :attr:`header_regex`, and
+    :attr:`record_map`. Override :meth:`preparse` or
+    :meth:`get_metadata` when needed.
+    """
+
+    name = None
+    header_regex = None
+    record_map = None
+
+    def can_handle(self, raw_header):
+        """Return True if this instrument owns *raw_header*.
+
+        Default implementation matches :attr:`header_regex` against
+        the bytes of the first ASTM frame.
+        """
+        if self.header_regex is None:
+            return False
+        return re.match(self.header_regex, raw_header) is not None
+
+    def preparse(self, raw):
+        """Hook for non-compliant transports.
+
+        Default: pass-through. Instruments whose wire format is not
+        valid ASTM (e.g. mini_vidas, spotchem) override this to
+        massage *raw* into a compliant message.
+        """
+        return raw
+
+    def get_metadata(self, wrapper):
+        """Optional per-instrument metadata merged into the envelope.
+
+        Default returns an empty dict.
+        """
+        return {}
+
+
+_REGISTRY = {}
+
+
+def register_instrument(cls):
+    """Decorator: register an :class:`Instrument` subclass.
+
+    Validates the class shape and instantiates it once. Re-registering
+    the same name replaces the previous entry (with a debug log) so
+    test fixtures can swap implementations.
+    """
+    if not isinstance(cls, type) or not issubclass(cls, Instrument):
+        raise TypeError(
+            "register_instrument expects an Instrument subclass, "
+            "got %r" % (cls,))
+    if not cls.name:
+        raise ValueError(
+            "Instrument %r must define a non-empty 'name'" % cls)
+    if cls.header_regex is None:
+        raise ValueError(
+            "Instrument %r must define 'header_regex'" % cls)
+    if not cls.record_map:
+        raise ValueError(
+            "Instrument %r must define a non-empty 'record_map'" % cls)
+    if cls.name in _REGISTRY:
+        logger.debug(
+            "Replacing already-registered instrument %r", cls.name)
+    _REGISTRY[cls.name] = cls()
+    return cls
+
+
+def unregister_instrument(name):
+    """Remove *name* from the registry. No-op when absent.
+
+    Intended for tests; production code should not call this.
+    """
+    _REGISTRY.pop(name, None)
+
+
+def registered_instruments():
+    """Return a tuple of registered :class:`Instrument` instances.
+
+    Order is the order of registration.
+    """
+    return tuple(_REGISTRY.values())
+
+
+def find_instrument(raw_header):
+    """Resolve the instrument that owns *raw_header*.
+
+    :param raw_header: bytes of the first ASTM message.
+    :returns: the matching :class:`Instrument` instance, or ``None``
+        when no instrument claims the header.
+    :raises AmbiguousInstrumentError: when more than one registered
+        instrument matches.
+    """
+    matches = [inst for inst in _REGISTRY.values()
+               if inst.can_handle(raw_header)]
+    if len(matches) > 1:
+        names = ", ".join(repr(m.name) for m in matches)
+        raise AmbiguousInstrumentError(
+            "Header matched multiple instruments: %s" % names)
+    if matches:
+        return matches[0]
+    return None
+
+
+__all__ = (
+    "AmbiguousInstrumentError",
+    "Instrument",
+    "find_instrument",
+    "register_instrument",
+    "registered_instruments",
+    "unregister_instrument",
+)

--- a/src/senaite/astm/core/instrument.py
+++ b/src/senaite/astm/core/instrument.py
@@ -25,6 +25,8 @@ import re
 
 from senaite.astm import logger
 
+_REGISTRY = {}
+
 
 class AmbiguousInstrumentError(LookupError):
     """Raised when more than one registered instrument matches the
@@ -70,9 +72,6 @@ class Instrument(object):
         Default returns an empty dict.
         """
         return {}
-
-
-_REGISTRY = {}
 
 
 def register_instrument(cls):

--- a/src/senaite/astm/tests/test_instrument_registry.py
+++ b/src/senaite/astm/tests/test_instrument_registry.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+import re
+import unittest
+
+from senaite.astm import records
+from senaite.astm.core.instrument import AmbiguousInstrumentError
+from senaite.astm.core.instrument import Instrument
+from senaite.astm.core.instrument import find_instrument
+from senaite.astm.core.instrument import register_instrument
+from senaite.astm.core.instrument import registered_instruments
+from senaite.astm.core.instrument import unregister_instrument
+
+
+def _make_record_map():
+    return {
+        "H": records.HeaderRecord,
+        "P": records.PatientRecord,
+        "O": records.OrderRecord,
+        "R": records.ResultRecord,
+        "C": records.CommentRecord,
+        "L": records.TerminatorRecord,
+    }
+
+
+class InstrumentRegistryTest(unittest.TestCase):
+
+    def setUp(self):
+        self._registered = []
+
+    def tearDown(self):
+        for name in self._registered:
+            unregister_instrument(name)
+
+    def _register(self, cls):
+        self._registered.append(cls.name)
+        return register_instrument(cls)
+
+    def test_registers_and_resolves_by_header(self):
+        @self._register
+        class FakeAlpha(Instrument):
+            name = "test:alpha"
+            header_regex = re.compile(rb".*FakeAlpha\^")
+            record_map = _make_record_map()
+
+        header = b"1H|\\^&|||FakeAlpha^v1|||||EPR||P|1|20260512|"
+        instrument = find_instrument(header)
+        self.assertIsNotNone(instrument)
+        self.assertEqual(instrument.name, "test:alpha")
+        self.assertIn(instrument, registered_instruments())
+
+    def test_unknown_header_returns_none(self):
+        @self._register
+        class FakeBeta(Instrument):
+            name = "test:beta"
+            header_regex = re.compile(rb".*FakeBeta\^")
+            record_map = _make_record_map()
+
+        self.assertIsNone(find_instrument(b"1H|\\^&|||Other^|||"))
+
+    def test_overlapping_regexes_raise(self):
+        @self._register
+        class FakeOne(Instrument):
+            name = "test:one"
+            header_regex = re.compile(rb".*Shared\^")
+            record_map = _make_record_map()
+
+        @self._register
+        class FakeTwo(Instrument):
+            name = "test:two"
+            header_regex = re.compile(rb".*Shared\^")
+            record_map = _make_record_map()
+
+        with self.assertRaises(AmbiguousInstrumentError):
+            find_instrument(b"1H|\\^&|||Shared^v|||")
+
+    def test_preparse_defaults_to_passthrough(self):
+        @self._register
+        class FakeGamma(Instrument):
+            name = "test:gamma"
+            header_regex = re.compile(rb".*Gamma\^")
+            record_map = _make_record_map()
+
+        raw = b"1H|\\^&|||Gamma^|||"
+        self.assertEqual(FakeGamma().preparse(raw), raw)
+
+    def test_preparse_hook_can_rewrite_bytes(self):
+        @self._register
+        class FakeDelta(Instrument):
+            name = "test:delta"
+            header_regex = re.compile(rb".*Delta\^")
+            record_map = _make_record_map()
+
+            def preparse(self, raw):
+                return raw.upper()
+
+        out = FakeDelta().preparse(b"hello")
+        self.assertEqual(out, b"HELLO")
+
+    def test_metadata_defaults_to_empty(self):
+        @self._register
+        class FakeEpsilon(Instrument):
+            name = "test:epsilon"
+            header_regex = re.compile(rb".*Epsilon\^")
+            record_map = _make_record_map()
+
+        self.assertEqual(FakeEpsilon().get_metadata(wrapper=None), {})
+
+    def test_registration_validates_required_attributes(self):
+        class Missing(Instrument):
+            pass
+
+        with self.assertRaises(ValueError):
+            register_instrument(Missing)
+
+        class MissingRegex(Instrument):
+            name = "test:no-regex"
+            record_map = _make_record_map()
+
+        with self.assertRaises(ValueError):
+            register_instrument(MissingRegex)
+
+        class MissingMap(Instrument):
+            name = "test:no-map"
+            header_regex = re.compile(rb".*x")
+
+        with self.assertRaises(ValueError):
+            register_instrument(MissingMap)
+
+    def test_non_instrument_subclass_rejected(self):
+        class NotAnInstrument(object):
+            name = "test:bogus"
+
+        with self.assertRaises(TypeError):
+            register_instrument(NotAnInstrument)
+
+
+class WrapperRegistryIntegrationTest(unittest.TestCase):
+    """Wrapper should consult the registry before falling back to
+    the legacy pkgutil discovery.
+    """
+
+    def setUp(self):
+        self._registered = []
+
+    def tearDown(self):
+        for name in self._registered:
+            unregister_instrument(name)
+
+    def _register(self, cls):
+        self._registered.append(cls.name)
+        return register_instrument(cls)
+
+    def test_wrapper_uses_registered_instrument(self):
+        from senaite.astm.wrapper import Wrapper
+
+        custom_map = {"H": records.HeaderRecord}
+
+        @self._register
+        class FakeMega(Instrument):
+            name = "test:mega"
+            header_regex = re.compile(rb".*MegaProbe\^")
+            record_map = custom_map
+
+        wrapper = Wrapper([b"1H|\\^&|||MegaProbe^|||"])
+        self.assertIs(wrapper.instrument.__class__, FakeMega)
+        self.assertEqual(set(wrapper.mapping), {"H"})
+
+    def test_wrapper_falls_back_to_legacy_discovery(self):
+        from senaite.astm.wrapper import Wrapper
+
+        # Header that matches the existing pkgutil-discovered
+        # Afinion 2 module; no registry entry needed.
+        header = b"1H|\\^&|||Afinion 2 Analyzer^^AF0000030|||||EPR||P|1|"
+        wrapper = Wrapper([header])
+        self.assertIsNone(wrapper.instrument)
+        # Legacy mapping must still resolve through pkgutil.
+        self.assertIn("H", wrapper.mapping)

--- a/src/senaite/astm/wrapper.py
+++ b/src/senaite/astm/wrapper.py
@@ -10,6 +10,7 @@ from senaite.astm import records
 from senaite.astm.constants import ENCODING
 from senaite.astm.core.envelope import Envelope
 from senaite.astm.core.envelope import Metadata
+from senaite.astm.core.instrument import find_instrument
 from senaite.astm.utils import split_message
 
 DEFAULT_MAPPING = {
@@ -29,16 +30,34 @@ class Wrapper(object):
     """
     def __init__(self, messages):
         self.messages = messages
-        self.mapping = self.get_mapping(messages)
+        self.instrument = None
         self.module = None
+        self.mapping = self.get_mapping(messages)
 
     def get_mapping(self, messages):
-        """Returns the record mapping for the message
+        """Returns the record mapping for the message.
+
+        Resolution order:
+
+        1. The instrument registry populated by
+           :func:`senaite.astm.core.instrument.register_instrument`.
+        2. Legacy ``pkgutil``-based discovery of
+           :mod:`senaite.astm.instruments` modules (kept until
+           every instrument is migrated; will be removed in PR-E2).
+        3. The :data:`DEFAULT_MAPPING` fallback.
         """
         if not messages:
             return DEFAULT_MAPPING
         header = messages[0]
 
+        instrument = find_instrument(header)
+        if instrument is not None:
+            self.instrument = instrument
+            return dict(instrument.record_map)
+
+        return self._legacy_mapping(header)
+
+    def _legacy_mapping(self, header):
         for importer, modname, ispkg in pkgutil.iter_modules(
                 instruments.__path__, instruments.__name__ + "."):
             module = __import__(modname, fromlist="dummy")
@@ -76,9 +95,7 @@ class Wrapper(object):
             "astm": self.to_astm(),
             "lis2a": self.to_lis2a(),
         }
-        get_metadata = getattr(self.module, "get_metadata", None)
-        if callable(get_metadata):
-            metadata_extras.update(get_metadata(self))
+        metadata_extras.update(self._collect_instrument_metadata())
 
         buckets = defaultdict(list)
         for message in self.messages:
@@ -97,6 +114,18 @@ class Wrapper(object):
             metadata=Metadata(**metadata_extras),
             **buckets,
         )
+
+    def _collect_instrument_metadata(self):
+        """Merge instrument-specific metadata from whichever
+        mechanism resolved the mapping.
+        """
+        if self.instrument is not None:
+            extras = self.instrument.get_metadata(self)
+            return dict(extras or {})
+        get_metadata = getattr(self.module, "get_metadata", None)
+        if callable(get_metadata):
+            return dict(get_metadata(self) or {})
+        return {}
 
     def to_dict(self):
         """Return the envelope as a plain JSON-serialisable dict.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

First half of the PR-E unification: collapse `senaite.astm.instruments` and `senaite.astm.adapters` into a single registry-based mechanism, so each new analyzer lives in one place. To keep CERMEL's staging window small, PR-E is split:

- **PR-E1 (this PR)** introduces the registry and protocol, and teaches `Wrapper.get_mapping()` to consult it first. No instrument has been migrated yet, so behaviour is unchanged for every existing analyzer.
- **PR-E2** will migrate each instrument (and the two `adapters/*` data handlers) into the new layout and remove the legacy `pkgutil`-based discovery together with `senaite.astm.adapters`.

## Current behavior before PR

Two parallel mechanisms exist for adding a new analyzer:

1. A flat module under `senaite.astm.instruments` discovered at runtime via `pkgutil.iter_modules`, identified by `HEADER_RX` and a `get_mapping()` callable. First match wins, silently.
2. Subdirectories under `senaite.astm.adapters` register `IDataHandler` adapters in a zope `Components` registry for instruments whose wire format is not valid ASTM (mini_vidas, spotchem se1520).

Two layouts, two registration styles, two import-time side effects, and no protection when two `HEADER_RX` patterns overlap.

## Desired behavior after PR is merged

- A new `senaite.astm.core.instrument` module:
  - `Instrument` base class describing an analyzer (`name`, `header_regex`, `record_map`, `can_handle`, `preparse`, `get_metadata`).
  - `register_instrument` decorator with input validation.
  - `find_instrument(raw_header)` resolver that raises `AmbiguousInstrumentError` instead of silently picking one match when two regexes overlap.
- `Wrapper.get_mapping()` consults the registry first; if no instrument is registered for the header, it falls back to today's `pkgutil` discovery so every existing analyzer keeps working. Instrument-specific metadata is collected through whichever mechanism matched.
- New `test_instrument_registry.py` covers registration, validation, regex-based resolution, overlap detection, the default `preparse` pass-through, an override, and the wrapper integration (registry hit + legacy fallback).
- 269 tests pass (+10 new). flake8 clean.

No `senaite.astm.instruments` module has been migrated to the new registry yet, so this PR is a strict superset of today's behavior. PR-E2 will perform the migration and remove the legacy path in one swing.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html