### PR TITLE
Server hardening: async main, sane log rotation, graceful shutdown (PR-G)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #34 Server hardening: async main, sane log rotation, graceful
+  shutdown of in-flight pipeline tasks (PR-G)
 - #33 Split transport from protocol semantics (PR-F)
 - #31 Migrate every instrument to the registry (PR-E2)
 - #30 Introduce the instrument registry (PR-E1)

--- a/src/senaite/astm/cli/astm_server.py
+++ b/src/senaite/astm/cli/astm_server.py
@@ -3,8 +3,9 @@
 
 Wires the slim ASTM transport (``transports/astm/protocol.py``) to
 the message :class:`Pipeline`. The transport emits complete frame
-batches; this module wraps them into an :class:`Envelope` and runs
-the pipeline against it.
+batches; this module wraps them into an :class:`Envelope`, dispatches
+the pipeline as a tracked task, and waits for in-flight work on
+shutdown.
 
 The CLI surface (arguments, default ports, logfile name) is
 preserved from the previous ``senaite.astm.server`` module.
@@ -12,10 +13,10 @@ preserved from the previous ``senaite.astm.server`` module.
 
 import argparse
 import asyncio
-import contextlib
 import logging
 import logging.handlers
 import os
+import signal
 import sys
 
 from senaite.astm import logger
@@ -28,6 +29,9 @@ from senaite.astm.transports.astm.protocol import ASTMProtocol
 from senaite.astm.wrapper import Wrapper
 
 LOGFILE = "senaite-astm-server.log"
+LOGFILE_MAX_BYTES = 10 * 1024 * 1024
+LOGFILE_BACKUP_COUNT = 5
+DEFAULT_SHUTDOWN_GRACE_SECONDS = 30
 
 
 def build_arg_parser():
@@ -46,6 +50,11 @@ def build_arg_parser():
     astm_group.add_argument(
         "-o", "--output", type=str,
         help="Output directory to write full messages")
+    astm_group.add_argument(
+        "--shutdown-grace-seconds", type=int,
+        default=DEFAULT_SHUTDOWN_GRACE_SECONDS,
+        help="Seconds to wait for in-flight handler tasks to "
+             "finish before forcefully cancelling them on shutdown.")
 
     lims_group.add_argument(
         "-u", "--url", type=str,
@@ -82,10 +91,10 @@ def build_arg_parser():
 
 def configure_logging(args):
     if args.logfile:
-        # NOTE: maxBytes=5 is preserved from the legacy server for
-        # behavioural parity. PR-G fixes this to a sane value.
         handler = logging.handlers.RotatingFileHandler(
-            args.logfile, maxBytes=5, backupCount=0)
+            args.logfile,
+            maxBytes=LOGFILE_MAX_BYTES,
+            backupCount=LOGFILE_BACKUP_COUNT)
         handler.setFormatter(logging.Formatter(
             "%(asctime)s %(levelname)-8s %(message)s"))
         logger.addHandler(handler)
@@ -129,27 +138,107 @@ def build_pipeline(args, session):
     return Pipeline(handlers)
 
 
-def make_frame_callback(loop, queue):
-    """Return a frame callback that pushes ``(client, frames)`` onto
-    the asyncio queue from the protocol's sync context.
+def make_frame_callback(loop, pipeline, task_set):
+    """Return a frame callback that dispatches a tracked pipeline run.
+
+    The protocol invokes the callback synchronously from the loop
+    thread (inside ``data_received``). We schedule the wrap + pipeline
+    work as a task so the protocol can return immediately, and we
+    register that task into ``task_set`` so shutdown can wait for it.
     """
     def frame_callback(client, frames):
-        loop.call_soon_threadsafe(queue.put_nowait, (client, frames))
+        task = loop.create_task(
+            _process_frames(client, frames, pipeline))
+        task_set.add(task)
+        task.add_done_callback(task_set.discard)
     return frame_callback
 
 
-async def consume(queue, pipeline):
-    """Consume frame batches off the queue and run the pipeline."""
-    while True:
-        client, frames = await queue.get()
+async def _process_frames(client, frames, pipeline):
+    try:
+        envelope = Wrapper(frames).to_envelope()
+    except Exception as exc:
+        logger.error(
+            "Failed to wrap %d frames from %s: %r",
+            len(frames), client, exc)
+        return
+    await pipeline.run(envelope)
+
+
+async def _drain_tasks(task_set, grace_seconds):
+    """Await all in-flight tasks up to ``grace_seconds``.
+
+    Tasks still running after the grace period are cancelled.
+    """
+    if not task_set:
+        return
+    logger.info(
+        "Waiting up to %ds for %d in-flight task(s) to finish...",
+        grace_seconds, len(task_set))
+    pending = list(task_set)
+    done, still_pending = await asyncio.wait(
+        pending, timeout=grace_seconds)
+    if still_pending:
+        logger.warning(
+            "Cancelling %d task(s) that did not finish within "
+            "the %ds grace period",
+            len(still_pending), grace_seconds)
+        for task in still_pending:
+            task.cancel()
+        await asyncio.gather(*still_pending, return_exceptions=True)
+
+
+async def amain(args, stop_event=None):
+    """Async entry point.
+
+    Boots the listener, installs signal handlers, and blocks until a
+    shutdown signal arrives.
+
+    :param stop_event: Optional pre-created :class:`asyncio.Event`
+        used to request shutdown. Tests can drive shutdown via this
+        event without going through OS signals.
+    """
+    loop = asyncio.get_running_loop()
+    task_set = set()
+    pipeline = build_pipeline(args, args.session)
+    frame_callback = make_frame_callback(loop, pipeline, task_set)
+
+    server = await loop.create_server(
+        lambda: ASTMProtocol(frame_callback=frame_callback),
+        host=args.listen, port=args.port)
+
+    for socket in server.sockets:
+        ip, port = socket.getsockname()
+        logger.info("Starting server on {}:{}".format(ip, port))
+    logger.info("ASTM server ready to handle connections ...")
+
+    if stop_event is None:
+        stop_event = asyncio.Event()
+
+    def request_shutdown(sig_name):
+        if stop_event.is_set():
+            return
+        logger.info("Received %s, initiating graceful shutdown", sig_name)
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
         try:
-            envelope = Wrapper(frames).to_envelope()
-        except Exception as exc:
-            logger.error(
-                "Failed to wrap %d frames from %s: %r",
-                len(frames), client, exc)
-            continue
-        await pipeline.run(envelope)
+            loop.add_signal_handler(
+                sig, request_shutdown, sig.name)
+        except (NotImplementedError, RuntimeError):
+            # Windows or non-main-thread loops can't install loop-level
+            # signal handlers. Fall back to default behaviour; callers
+            # that need programmatic shutdown can pass ``stop_event``.
+            pass
+
+    try:
+        await stop_event.wait()
+    finally:
+        logger.info("Shutting down server...")
+        server.close()
+        await server.wait_closed()
+        await _drain_tasks(task_set, args.shutdown_grace_seconds)
+        logger.info("Server is now down...")
 
 
 def main():
@@ -158,38 +247,15 @@ def main():
 
     configure_logging(args)
     validate_output(args.output)
-    session = validate_lims(args.url)
-
-    loop = asyncio.get_event_loop()
-    queue = asyncio.Queue()
-    pipeline = build_pipeline(args, session)
-    frame_callback = make_frame_callback(loop, queue)
-
-    loop.create_task(consume(queue, pipeline))
-
-    server_coro = loop.create_server(
-        lambda: ASTMProtocol(frame_callback=frame_callback),
-        host=args.listen, port=args.port)
-    server = loop.run_until_complete(server_coro)
-
-    for socket in server.sockets:
-        ip, port = socket.getsockname()
-        logger.info("Starting server on {}:{}".format(ip, port))
-        logger.info("ASTM server ready to handle connections ...")
+    args.session = validate_lims(args.url)
 
     try:
-        loop.run_forever()
+        asyncio.run(amain(args))
     except KeyboardInterrupt:
-        logger.info("Shutting down server...")
-        all_tasks = asyncio.gather(
-            *asyncio.all_tasks(loop), return_exceptions=True)
-        all_tasks.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            loop.run_until_complete(all_tasks)
-        loop.run_until_complete(loop.shutdown_asyncgens())
-    finally:
-        loop.close()
-        logger.info("Server is now down...")
+        # Reach this only on platforms where the loop's signal handler
+        # is unavailable (Windows). The graceful path runs via
+        # ``request_shutdown``.
+        logger.info("Interrupted; exiting.")
 
 
 if __name__ == "__main__":

--- a/src/senaite/astm/tests/test_server_lifecycle.py
+++ b/src/senaite/astm/tests/test_server_lifecycle.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+"""Tests for the hardened CLI server lifecycle.
+
+PR-G replaced the legacy ``server.main`` with an async ``amain``
+that:
+
+- writes its logfile via a sane :class:`RotatingFileHandler` (10 MB
+  per file, 5 backups) instead of rotating after every record;
+- tracks every pipeline-run task it dispatches so shutdown can
+  ``await`` in-flight work;
+- waits up to ``--shutdown-grace-seconds`` for those tasks before
+  cancelling them.
+
+The tests below cover those guarantees without orchestrating a real
+SIGTERM (which is fiddly under ``pytest``): they exercise
+``_drain_tasks``, ``make_frame_callback`` and the logging setup
+directly.
+"""
+
+import asyncio
+import logging
+import logging.handlers
+import os
+import tempfile
+import unittest
+
+from senaite.astm import logger
+from senaite.astm.cli import astm_server
+
+
+class _Args(object):
+    """Minimal stand-in for the argparse Namespace."""
+
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class LogRotationTest(unittest.TestCase):
+
+    def test_constants_are_sane(self):
+        # 5-byte rotation was a real bug in the legacy server.
+        self.assertGreaterEqual(astm_server.LOGFILE_MAX_BYTES, 1024 * 1024)
+        self.assertGreaterEqual(astm_server.LOGFILE_BACKUP_COUNT, 1)
+
+    def test_configure_logging_does_not_rotate_per_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            logfile = os.path.join(tmp, "server.log")
+            args = _Args(logfile=logfile, verbose=False)
+
+            # Snapshot existing handlers so we can detach what we add.
+            before = list(logger.handlers)
+            try:
+                astm_server.configure_logging(args)
+                # Find the rotating handler we just attached.
+                rotating = [h for h in logger.handlers
+                            if isinstance(
+                                h, logging.handlers.RotatingFileHandler)]
+                self.assertEqual(len(rotating), 1)
+                handler = rotating[0]
+                self.assertEqual(
+                    handler.maxBytes, astm_server.LOGFILE_MAX_BYTES)
+                self.assertEqual(
+                    handler.backupCount,
+                    astm_server.LOGFILE_BACKUP_COUNT)
+
+                # Emit a few records — none should rotate.
+                for _ in range(20):
+                    logger.info("a log line that easily exceeds 5 bytes")
+                handler.flush()
+
+                rotated = [
+                    name for name in os.listdir(tmp)
+                    if name.startswith("server.log.")
+                ]
+                self.assertEqual(rotated, [])
+            finally:
+                # Restore the logger to its pre-test state so other
+                # tests are not noisy.
+                for h in list(logger.handlers):
+                    if h not in before:
+                        logger.removeHandler(h)
+
+
+class DrainTasksTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_returns_immediately_when_empty(self):
+        await astm_server._drain_tasks(set(), grace_seconds=5)
+
+    async def test_waits_for_inflight_task(self):
+        completed = []
+
+        async def slow():
+            await asyncio.sleep(0.05)
+            completed.append(True)
+
+        task = asyncio.create_task(slow())
+        await astm_server._drain_tasks({task}, grace_seconds=2)
+        self.assertEqual(completed, [True])
+        self.assertTrue(task.done())
+
+    async def test_cancels_tasks_that_exceed_grace(self):
+        async def stuck():
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(stuck())
+        await astm_server._drain_tasks({task}, grace_seconds=0.05)
+        self.assertTrue(task.cancelled())
+
+
+class FrameCallbackTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_callback_runs_pipeline_against_wrapped_envelope(self):
+        seen_envelopes = []
+
+        async def capture_handler(envelope):
+            seen_envelopes.append(envelope)
+
+        from senaite.astm.core.pipeline import Pipeline
+
+        pipeline = Pipeline([capture_handler])
+        loop = asyncio.get_running_loop()
+        task_set = set()
+        callback = astm_server.make_frame_callback(
+            loop, pipeline, task_set)
+
+        frames = [
+            b"\x021H|\\^&|||C111^Roche^c111^4.2.2.1730^1^13147|||||"
+            b"host|RSUPL^REAL|P|1|20230727162028\r\x179B\r\n",
+            b"\x027L|1|N\r\x030A\r\n",
+        ]
+        callback("127.0.0.1:11111", frames)
+
+        # Task must be tracked synchronously so shutdown can wait
+        self.assertEqual(len(task_set), 1)
+
+        # Drain via the production helper to prove the contract holds.
+        await astm_server._drain_tasks(task_set, grace_seconds=2)
+
+        self.assertEqual(len(seen_envelopes), 1)
+        self.assertEqual(len(seen_envelopes[0].H), 1)
+        self.assertEqual(task_set, set())
+
+    async def test_wrap_failure_does_not_crash_dispatch(self):
+        called = []
+
+        async def handler(envelope):
+            called.append(envelope)
+
+        from senaite.astm.core.pipeline import Pipeline
+
+        pipeline = Pipeline([handler])
+        loop = asyncio.get_running_loop()
+        task_set = set()
+        callback = astm_server.make_frame_callback(
+            loop, pipeline, task_set)
+
+        # Garbage frames that will not parse.
+        callback("127.0.0.1:11111", [b"not-a-frame"])
+        await astm_server._drain_tasks(task_set, grace_seconds=2)
+
+        self.assertEqual(called, [])
+
+
+class GracefulShutdownTest(unittest.IsolatedAsyncioTestCase):
+    """Boot the server, dispatch a slow in-flight task, request
+    shutdown, and assert the task ran to completion before
+    ``amain`` returned."""
+
+    PORT = 7984
+
+    async def test_inflight_task_completes_before_amain_returns(self):
+        completed = asyncio.Event()
+        observed_during_shutdown = []
+
+        async def slow_handler(envelope):
+            # Sleep across the shutdown moment to prove drain waits.
+            await asyncio.sleep(0.2)
+            completed.set()
+            observed_during_shutdown.append(True)
+
+        # Patch the pipeline builder so we don't need a live LIMS.
+        from senaite.astm.core.pipeline import Pipeline
+
+        original_build = astm_server.build_pipeline
+        astm_server.build_pipeline = lambda args, session: Pipeline(
+            [slow_handler])
+        try:
+            args = _Args(
+                listen="127.0.0.1",
+                port=self.PORT,
+                output=None,
+                url=None,
+                session=None,
+                shutdown_grace_seconds=5,
+                consumer="x",
+                message_format="json",
+                retries=1,
+                delay=0,
+            )
+
+            stop_event = asyncio.Event()
+            server_task = asyncio.create_task(
+                astm_server.amain(args, stop_event=stop_event))
+
+            # Give the server a moment to start listening.
+            await asyncio.sleep(0.05)
+
+            # Send one full ASTM session to trigger the slow handler.
+            from senaite.astm.constants import ACK, ENQ, EOT
+            reader, writer = await asyncio.open_connection(
+                "127.0.0.1", self.PORT)
+            writer.write(ENQ)
+            await writer.drain()
+            self.assertEqual(await reader.read(100), ACK)
+            # Single non-chunked terminator frame — enough to put the
+            # protocol's EOT into "has messages" mode. ETX (\x03)
+            # rather than ETB (\x17) keeps it out of chunked mode.
+            frame = b"\x021L|1|N\r\x0304\r\n"
+            writer.write(frame)
+            await writer.drain()
+            self.assertEqual(await reader.read(100), ACK)
+            writer.write(EOT)
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+            # Wait until the slow handler is in-flight, then request
+            # graceful shutdown via the test-injected stop event.
+            await asyncio.sleep(0.05)
+            stop_event.set()
+
+            await asyncio.wait_for(server_task, timeout=5)
+            self.assertTrue(completed.is_set())
+            self.assertEqual(observed_during_shutdown, [True])
+        finally:
+            astm_server.build_pipeline = original_build
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replace the legacy synchronous server entry point with a properly
async one and stop losing in-flight messages on shutdown.

## Summary

- **Async `amain()`** — boots the listener, installs SIGINT/SIGTERM
  handlers via `loop.add_signal_handler`, and blocks on an
  `asyncio.Event` until shutdown is requested. Tests can inject the
  `stop_event` to drive shutdown without OS signals.
- `main()` now wraps `amain` via `asyncio.run`, replacing the
  deprecated `asyncio.get_event_loop()` / `loop.run_until_complete`
  pair.
- **Tracked task set** — every pipeline run is dispatched as a
  tracked `asyncio.Task`. On shutdown `amain` calls
  `_drain_tasks(task_set, args.shutdown_grace_seconds)`, awaiting
  in-flight handlers up to the grace period and cancelling whatever
  remains. New CLI flag `--shutdown-grace-seconds` (default 30s).
- **Sane log rotation** — `RotatingFileHandler` now uses 10 MB /
  5 backups. The legacy `maxBytes=5` (yes, five bytes) rotated after
  every record.
- **Frame callback** schedules wrap + pipeline as a coroutine task
  on the loop and registers it with the tracked set, so the
  protocol's `data_received` returns immediately.

## Test plan

- [x] `python -m pytest src/senaite/astm/tests/` — 289 passed, 1 skipped.
- [x] `flake8 --config ci_flake8.cfg src/senaite/astm` — clean.
- [x] New `test_server_lifecycle.py`:
  - `LOGFILE_MAX_BYTES` / `LOGFILE_BACKUP_COUNT` are sane.
  - 20 log records do not trigger a rotation.
  - `_drain_tasks` returns immediately for an empty set, awaits an
    in-flight task, and cancels stragglers past the grace period.
  - `frame_callback` wraps + dispatches + tracks the task
    synchronously; bad frames do not crash the dispatcher.
  - `amain` awaits an in-flight slow handler before returning on
    shutdown, even when the connection has already closed.

## Next

PR-H makes disk capture a first-class handler and removes the
implicit `\$CWD/astm_messages/` directory. After that, the HL7
listener for HemoScreen is purely additive.