### PR TITLE
Use microsecond precision in capture filenames

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #38 Capture filename uses microsecond precision so messages
+  arriving within the same wall-clock second no longer overwrite
+  each other on disk. Observed on the HemoScreen HL7 instrument,
+  which sends its OBS/LQC/PRF triplet within ~200 ms.
 - #37 HL7 v2 parser, envelope mapping, and LIMS push wiring for
   the HL7 transport (PR-7). New ``transports/hl7/parser.py`` maps
   MSH/PID/OBR/OBX/NTE into the existing Envelope buckets

--- a/src/senaite/astm/utils.py
+++ b/src/senaite/astm/utils.py
@@ -30,8 +30,14 @@ def f(s, e="utf-8", **kw):
                        CRLF=u(CRLF), **kw).encode(e)
 
 
-def write_message(message, path, dateformat="%Y-%m-%d_%H:%M:%S", ext=".txt"):
+def write_message(message, path, dateformat="%Y-%m-%d_%H:%M:%S.%f",
+                  ext=".txt"):
     """Write ASTM Message to file
+
+    The default ``dateformat`` includes microseconds so two messages
+    that arrive within the same second do not silently overwrite
+    each other on disk. The HemoScreen HL7 instrument, for example,
+    pushes its OBS/LQC/PRF triplet within a few hundred milliseconds.
     """
     path = Path(path)
     if not path.exists():


### PR DESCRIPTION
The capture filename used second-resolution timestamps, so any two messages arriving within the same wall-clock second silently overwrote each other on disk.

## Where it bit us

Today's HemoScreen connection on a real-world install:

```
10:50:07,596 -> HL7 data from 192.168.5.99:49696: 1312 bytes  (control id 0)
10:50:07,631 -> HL7 data from 192.168.5.99:49696: 1307 bytes  (control id 1)
10:50:07,672 -> HL7 data from 192.168.5.99:49696: 1307 bytes  (control id 2)
10:50:07,714 -> HL7 data from 192.168.5.99:49696: 1307 bytes  (control id 3)
```

Four MSH messages in 118 ms, every one ACKed. Disk capture afterwards: exactly one `.hl7` file (control id `3`, the last writer wins). The OBS/LQC/PRF results from control ids 0–2 were dropped.

## Fix

Default `dateformat` in `senaite.astm.utils.write_message` now includes `%f` (microseconds):

```python
def write_message(message, path,
                  dateformat="%Y-%m-%d_%H:%M:%S.%f", ext=".txt"):
```

Microsecond resolution is more than enough — the listener can write at most one payload per `Pipeline` step, and `datetime.now()` on Linux returns microseconds verbatim from `clock_gettime(CLOCK_REALTIME)`. The storage layout is unchanged: still one file per message in `--output`, still `<timestamp><ext>`.

Both transports (ASTM and HL7) benefit; both have the same collision risk under bursty transmissions.

## Test plan

- [x] `python -m pytest src/senaite/astm/tests/` — 340 passed, 1 skipped.
- [x] `flake8 --config ci_flake8.cfg src/senaite/astm/utils.py` — clean.

No tests assert the old `%Y-%m-%d_%H:%M:%S` filename format, so this is a drop-in.

## Filename example

Before: `2026-05-21_10:50:07.hl7`
After:  `2026-05-21_10:50:07.596123.hl7`
