### PR TITLE
Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames
 - #37 HL7 v2 parser, envelope mapping, LIMS push wiring (PR-7)

--- a/src/senaite/astm/wrapper.py
+++ b/src/senaite/astm/wrapper.py
@@ -65,8 +65,6 @@ class Wrapper(object):
         See :mod:`senaite.astm.core.envelope` for the schema and
         the contract guarantees.
         """
-        mapping = self.get_mapping(self.messages)
-
         metadata_extras = {
             "astm": self.to_astm(),
             "lis2a": self.to_lis2a(),
@@ -77,13 +75,13 @@ class Wrapper(object):
         for message in self.messages:
             for record in codec.decode(message):
                 rtype = record[0]
-                if rtype not in mapping:
+                if rtype not in self.mapping:
                     continue
                 try:
-                    wrapped = mapping[rtype](*record)
+                    wrapped = self.mapping[rtype](*record)
                 except ValueError as exc:
-                    raise ValueError("Could not wrap '%s' record! (%s)"
-                                     % (rtype, str(exc)))
+                    raise ValueError(
+                        "Could not wrap '%s' record" % rtype) from exc
                 buckets[rtype].append(wrapped.to_dict())
 
         return Envelope(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Minor cleanup of `senaite.astm.wrapper.Wrapper.to_envelope`.

## Current behavior before PR

- `Wrapper.__init__` calls `self.get_mapping(messages)` and stores the result on `self.mapping`, then `to_envelope` calls `get_mapping(self.messages)` a second time with the same input.
- A `ValueError` raised inside a per-record wrap is caught and re-raised with `%s`-formatted text, losing the original traceback.

## Desired behavior after PR is merged

- `to_envelope` reads `self.mapping` directly — no redundant re-parse.
- The re-raised `ValueError` uses `raise ... from exc` so the original cause is preserved.

No behavior change for callers. Tests stay green.