### PR TITLE
Instrument base: provide a default get_metadata returning version + header_rx

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #43 Instrument base: provide a default get_metadata returning version + header_rx
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/core/instrument.py
+++ b/src/senaite/astm/core/instrument.py
@@ -46,6 +46,10 @@ class Instrument(object):
     name = None
     header_regex = None
     record_map = None
+    #: Schema version of the per-instrument record map. Bump in the
+    #: subclass when the record layout changes in a way consumers
+    #: must adapt to.
+    version = "1.0.0"
     #: Optional bytes regex used by :func:`find_raw_data_handler`
     #: to dispatch non-ASTM transport packets to this instrument
     #: before the standard ENQ/STX/EOT state machine sees them.
@@ -86,11 +90,17 @@ class Instrument(object):
         return None
 
     def get_metadata(self, wrapper):
-        """Optional per-instrument metadata merged into the envelope.
+        """Per-instrument metadata merged into the envelope.
 
-        Default returns an empty dict.
+        Default exposes the schema :attr:`version` and the
+        :attr:`header_regex` pattern. Override to add vendor-specific
+        keys; call ``super().get_metadata(wrapper)`` first to keep
+        the defaults.
         """
-        return {}
+        pattern = self.header_regex.pattern
+        if isinstance(pattern, bytes):
+            pattern = pattern.decode()
+        return {"version": self.version, "header_rx": pattern}
 
 
 def register_instrument(cls):

--- a/src/senaite/astm/instruments/abbott_afinion2.py
+++ b/src/senaite/astm/instruments/abbott_afinion2.py
@@ -181,6 +181,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class AbbottAfinion2(Instrument):
     name = "abbott_afinion2"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -190,9 +191,6 @@ class AbbottAfinion2(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION, "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = AbbottAfinion2()

--- a/src/senaite/astm/instruments/biomerieux_mini_vidas.py
+++ b/src/senaite/astm/instruments/biomerieux_mini_vidas.py
@@ -96,6 +96,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class BiomerieuxMiniVidas(Instrument):
     name = "biomerieux_mini_vidas"
     header_regex = HEADER_RX
+    version = VERSION
     raw_data_regex = RAW_DATA_RX
     record_map = {
         "H": HeaderRecord,
@@ -104,10 +105,6 @@ class BiomerieuxMiniVidas(Instrument):
         "R": ResultRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
     def _to_timestamp(self, date, time):
         dt = datetime.now()

--- a/src/senaite/astm/instruments/dca_vantage.py
+++ b/src/senaite/astm/instruments/dca_vantage.py
@@ -162,6 +162,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class DCAVantage(Instrument):
     name = "dca_vantage"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -172,9 +173,6 @@ class DCAVantage(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION, "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = DCAVantage()

--- a/src/senaite/astm/instruments/genexpert.py
+++ b/src/senaite/astm/instruments/genexpert.py
@@ -285,6 +285,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class GeneXpert(Instrument):
     name = "genexpert"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -295,10 +296,6 @@ class GeneXpert(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = GeneXpert()

--- a/src/senaite/astm/instruments/horiba_pentra_xlr.py
+++ b/src/senaite/astm/instruments/horiba_pentra_xlr.py
@@ -198,6 +198,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class HoribaPentraXLR(Instrument):
     name = "horiba_pentra_xlr"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -208,10 +209,6 @@ class HoribaPentraXLR(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = HoribaPentraXLR()

--- a/src/senaite/astm/instruments/horiba_yumizen_h5xx.py
+++ b/src/senaite/astm/instruments/horiba_yumizen_h5xx.py
@@ -131,6 +131,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class HoribaYumizenH5xx(Instrument):
     name = "horiba_yumizen_h5xx"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -141,10 +142,6 @@ class HoribaYumizenH5xx(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = HoribaYumizenH5xx()

--- a/src/senaite/astm/instruments/roche_cobas_c111.py
+++ b/src/senaite/astm/instruments/roche_cobas_c111.py
@@ -167,6 +167,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class RocheCobasC111(Instrument):
     name = "roche_cobas_c111"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -177,10 +178,6 @@ class RocheCobasC111(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = RocheCobasC111()

--- a/src/senaite/astm/instruments/roche_cobas_c311.py
+++ b/src/senaite/astm/instruments/roche_cobas_c311.py
@@ -153,6 +153,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class RocheCobasC311(Instrument):
     name = "roche_cobas_c311"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -163,10 +164,6 @@ class RocheCobasC311(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = RocheCobasC311()

--- a/src/senaite/astm/instruments/spotchem_el.py
+++ b/src/senaite/astm/instruments/spotchem_el.py
@@ -85,6 +85,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class SpotchemEL(Instrument):
     name = "spotchem_el"
     header_regex = HEADER_RX
+    version = VERSION
     raw_data_regex = RAW_DATA_RX
     record_map = {
         "H": HeaderRecord,
@@ -92,10 +93,6 @@ class SpotchemEL(Instrument):
         "R": ResultRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
     def handle_raw_data(self, protocol, data):
         """Synthesise a complete ASTM session from a single non-ASTM

--- a/src/senaite/astm/instruments/sysmex_xn.py
+++ b/src/senaite/astm/instruments/sysmex_xn.py
@@ -214,6 +214,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class SysmexXN(Instrument):
     name = "sysmex_xn"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -224,10 +225,6 @@ class SysmexXN(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = SysmexXN()

--- a/src/senaite/astm/instruments/sysmex_xp.py
+++ b/src/senaite/astm/instruments/sysmex_xp.py
@@ -148,6 +148,7 @@ class TerminatorRecord(records.TerminatorRecord):
 class SysmexXP(Instrument):
     name = "sysmex_xp"
     header_regex = HEADER_RX
+    version = VERSION
     record_map = {
         "H": HeaderRecord,
         "P": PatientRecord,
@@ -158,10 +159,6 @@ class SysmexXP(Instrument):
         "M": ManufacturerInfoRecord,
         "L": TerminatorRecord,
     }
-
-    def get_metadata(self, wrapper):
-        return {"version": VERSION,
-                "header_rx": HEADER_RX.pattern.decode()}
 
 
 INSTRUMENT = SysmexXP()

--- a/src/senaite/astm/tests/test_instrument_registry.py
+++ b/src/senaite/astm/tests/test_instrument_registry.py
@@ -99,14 +99,17 @@ class InstrumentRegistryTest(unittest.TestCase):
         self.assertIsNotNone(find_raw_data_handler(b"\x02DELTA-payload"))
         self.assertIsNone(find_raw_data_handler(b"unrelated"))
 
-    def test_metadata_defaults_to_empty(self):
+    def test_metadata_defaults_expose_version_and_header_rx(self):
         @self._register
         class FakeEpsilon(Instrument):
             name = "test:epsilon"
             header_regex = re.compile(rb".*Epsilon\^")
             record_map = _make_record_map()
 
-        self.assertEqual(FakeEpsilon().get_metadata(wrapper=None), {})
+        self.assertEqual(
+            FakeEpsilon().get_metadata(wrapper=None),
+            {"version": "1.0.0", "header_rx": ".*Epsilon\\^"},
+        )
 
     def test_registration_validates_required_attributes(self):
         class Missing(Instrument):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Every registered instrument used to declare an identical `get_metadata` method returning `{"version": VERSION, "header_rx": HEADER_RX.pattern.decode()}`. That is pure boilerplate and adds noise to every adapter.

## Current behavior before PR

- `Instrument.get_metadata` defaults to `{}`.
- All 11 shipped adapters override it with the same 3-line body, just to expose their version and header regex.

## Desired behavior after PR is merged

- `Instrument` declares a `version = "1.0.0"` class attribute and a default `get_metadata` that returns `{"version": self.version, "header_rx": self.header_regex.pattern.decode()}`.
- Each adapter sets `version = VERSION` next to `header_regex = HEADER_RX` and drops the `get_metadata` override.
- Adapters that need vendor extras simply override `get_metadata` and call `super().get_metadata(wrapper)` first.
- Registry test is renamed to `test_metadata_defaults_expose_version_and_header_rx` and asserts the new default.