### PR TITLE
ASTMProtocol: rename discard_env to reset_session_state and prefer get_running_loop

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #44 ASTMProtocol: rename discard_env to reset_session_state and prefer get_running_loop
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/transports/astm/protocol.py
+++ b/src/senaite/astm/transports/astm/protocol.py
@@ -56,11 +56,16 @@ class ASTMProtocol(asyncio.Protocol):
     # ------------------------------------------------------------------
 
     def connection_made(self, transport):
-        # NOTE: ``asyncio.get_event_loop()`` is preserved here for
-        # behavioural parity with the legacy protocol; PR-G replaces
-        # this with ``asyncio.get_running_loop()`` and a properly
-        # async ``main()``.
-        self.loop = asyncio.get_event_loop()
+        # In production the server is always running inside an
+        # asyncio loop, so ``get_running_loop()`` is the right
+        # call and avoids the ``DeprecationWarning`` emitted by
+        # ``get_event_loop()`` on Python 3.12+. Synchronous unit
+        # tests instantiate the protocol outside a loop; fall back
+        # to a fresh loop so they keep working.
+        try:
+            self.loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
         self.transport = transport
         self.client = self.get_client_key(transport)
         logger.debug("Connection from {!s}".format(self.client))
@@ -109,14 +114,16 @@ class ASTMProtocol(asyncio.Protocol):
         return "{:s}:{:d}".format(*peername)
 
     def close_connection(self):
-        self.discard_env()
+        self.reset_session_state()
         if self.transport is not None:
             self.transport.close()
 
     def discard_chunked_messages(self):
         self.chunks = []
 
-    def discard_env(self):
+    def reset_session_state(self):
+        """Drop any partial session state so the protocol is ready
+        for the next ENQ/STX/EOT cycle."""
         self.chunks = []
         self.messages = []
         self.in_transfer_state = False
@@ -175,12 +182,12 @@ class ASTMProtocol(asyncio.Protocol):
         # XXX: Seen from Yumizen H550: EOT right after ENQ.
         #      Maybe this is some kind of keepalive?
         if not self.messages:
-            self.discard_env()
+            self.reset_session_state()
             return
 
         frames = list(self.messages)
         self.dispatch_frames(frames)
-        self.discard_env()
+        self.reset_session_state()
 
     def on_message(self, data):
         logger.debug("on_message: %r", data)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Two small cleanups to `transports/astm/protocol.py`:

1. `discard_env` does not say what an "env" is. The method actually resets per-session protocol state (chunks, messages, in_transfer_state).
2. `connection_made` uses `asyncio.get_event_loop()` with a stale "PR-G will fix this later" NOTE. PR-G shipped; the server now always runs inside a real loop, and `get_event_loop()` triggers a `DeprecationWarning` on Python 3.12+.

## Current behavior before PR

- Method is called `discard_env`; readers must dig in to find out what gets discarded.
- `asyncio.get_event_loop()` is used unconditionally; modern Python emits a deprecation warning.

## Desired behavior after PR is merged

- Method renamed to `reset_session_state` with a one-line docstring; all three call sites updated.
- `connection_made` uses `asyncio.get_running_loop()` in production. Synchronous unit tests still work because we fall back to `asyncio.new_event_loop()` when no loop is running (only relevant in tests that instantiate the protocol outside a loop).