### PR TITLE
lims.Session: drop unused **kw, return None from auth(), promote post_to_senaite kwargs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #45 lims.Session: drop unused **kw, return None from auth(), promote post_to_senaite kwargs
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/core/lims.py
+++ b/src/senaite/astm/core/lims.py
@@ -60,7 +60,7 @@ class Session(object):
     connection rather than being repeated for every request.
     """
 
-    def __init__(self, url, **kw):
+    def __init__(self, url):
         auth = requests.utils.get_auth_from_url(url)
         self.username = auth[0]
         self.password = auth[1]
@@ -75,7 +75,6 @@ class Session(object):
     def auth(self):
         """Authenticate against SENAITE.
 
-        :returns: True on success.
         :raises SenaiteAuthError: when the JSON API is missing or the
             credentials are rejected.
         :raises SenaiteUnreachableError: when the host cannot be
@@ -95,7 +94,6 @@ class Session(object):
 
         logger.info("Session established ('{}') with '{}'"
                     .format(self.username, self.url))
-        return True
 
     def post(self, endpoint, payload):
         """Send a POST request to SENAITE.
@@ -143,7 +141,8 @@ class Session(object):
         return "{}/{}/{}".format(self.url, API_BASE_URL, endpoint)
 
 
-def post_to_senaite(messages, session, **kwargs):
+def post_to_senaite(messages, session, retries=DEFAULT_RETRIES,
+                    delay=DEFAULT_DELAY, consumer=DEFAULT_CONSUMER):
     """POST ASTM messages to SENAITE.
 
     Authenticates **once** per call. Retries on push failure only
@@ -151,10 +150,6 @@ def post_to_senaite(messages, session, **kwargs):
 
     :returns: A :class:`PushResult` describing the outcome.
     """
-    retries = kwargs.get("retries", DEFAULT_RETRIES)
-    delay = kwargs.get("delay", DEFAULT_DELAY)
-    consumer = kwargs.get("consumer", DEFAULT_CONSUMER)
-
     try:
         session.auth()
     except SenaiteError as exc:

--- a/src/senaite/astm/tests/test_lims.py
+++ b/src/senaite/astm/tests/test_lims.py
@@ -77,7 +77,8 @@ class SessionAuthTest(unittest.TestCase):
     @responses.activate
     def test_auth_happy_path(self):
         auth_ok()
-        self.assertTrue(Session(URL).auth())
+        # auth() returns None on success and raises on failure.
+        self.assertIsNone(Session(URL).auth())
 
     @responses.activate
     def test_auth_raises_when_jsonapi_missing(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Three small API tidies in `core/lims.py`.

## Current behavior before PR

- `Session.__init__(self, url, **kw)` accepts arbitrary keyword arguments that no caller passes and that the constructor immediately ignores.
- `Session.auth()` only ever returns `True` (otherwise it raises); the return value is dead code at every call site.
- `post_to_senaite(messages, session, **kwargs)` accepts three optional keys (`retries`, `delay`, `consumer`) but receives them through `**kwargs`. The signature does not document what callers can pass, even though `LimsPushHandler` already declares these as explicit keyword arguments and then unpacks them back into `**kwargs`.

## Desired behavior after PR is merged

- `Session.__init__(self, url)` — explicit signature.
- `Session.auth()` returns `None`; raises on failure.
- `post_to_senaite(messages, session, retries=DEFAULT_RETRIES, delay=DEFAULT_DELAY, consumer=DEFAULT_CONSUMER)` — the signature is the documentation.

The existing happy-path test is updated to assert `assertIsNone(Session(URL).auth())`.