### PR TITLE
Pipeline: add optional dead_letter sink for failed handlers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #46 Pipeline: add optional dead_letter sink for failed handlers
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/core/pipeline.py
+++ b/src/senaite/astm/core/pipeline.py
@@ -25,10 +25,18 @@ class Pipeline(object):
     :param handlers: Iterable of async or sync callables that accept
         a single envelope argument. Sync callables are executed via
         :func:`asyncio.to_thread`.
+    :param dead_letter: Optional async or sync callable invoked as
+        ``dead_letter(envelope, handler_name, exception)`` whenever a
+        regular handler raises. Use it to write the offending
+        envelope to a forensic sink so no message is silently lost.
+        Exceptions raised by the dead-letter sink itself are logged
+        and swallowed — it is the last line of defense and must
+        not crash the pipeline.
     """
 
-    def __init__(self, handlers=None):
+    def __init__(self, handlers=None, dead_letter=None):
         self.handlers = list(handlers or [])
+        self.dead_letter = dead_letter
 
     def add(self, handler):
         """Append a handler to the pipeline."""
@@ -42,6 +50,11 @@ class Pipeline(object):
 
         Returns a list of ``(handler_name, exception_or_None)`` in
         the order the handlers were registered.
+
+        ``asyncio.CancelledError`` derives from ``BaseException``
+        (Python 3.8+), so the ``except Exception`` below does not
+        swallow shutdown signals — they propagate so ``amain`` can
+        cancel cleanly.
         """
         results = []
         for handler in self.handlers:
@@ -53,7 +66,23 @@ class Pipeline(object):
                 logger.error(
                     "Pipeline handler %r failed: %r", name, exc)
                 results.append((name, exc))
+                await self._notify_dead_letter(envelope, name, exc)
         return results
+
+    async def _notify_dead_letter(self, envelope, handler_name, exc):
+        if self.dead_letter is None:
+            return
+        try:
+            if inspect.iscoroutinefunction(self.dead_letter):
+                await self.dead_letter(envelope, handler_name, exc)
+            else:
+                result = self.dead_letter(envelope, handler_name, exc)
+                if inspect.isawaitable(result):
+                    await result
+        except Exception as dl_exc:
+            logger.error(
+                "Dead-letter sink raised %r while handling failure "
+                "from %r: %r", dl_exc, handler_name, exc)
 
     @staticmethod
     async def _invoke(handler, envelope):

--- a/src/senaite/astm/tests/test_pipeline.py
+++ b/src/senaite/astm/tests/test_pipeline.py
@@ -109,6 +109,62 @@ class PipelineTest(unittest.IsolatedAsyncioTestCase):
         pipeline.add(h)
         self.assertEqual(len(pipeline), 1)
 
+    async def test_dead_letter_called_when_handler_fails(self):
+        seen = []
+
+        async def boom(env):
+            raise RuntimeError("nope")
+
+        async def dl(env, name, exc):
+            seen.append((env, name, type(exc)))
+
+        pipeline = Pipeline(handlers=[boom], dead_letter=dl)
+        await pipeline.run("env-1")
+        self.assertEqual(seen, [("env-1", "boom", RuntimeError)])
+
+    async def test_dead_letter_not_called_when_handler_succeeds(self):
+        seen = []
+
+        async def ok(env):
+            pass
+
+        async def dl(env, name, exc):
+            seen.append(name)
+
+        pipeline = Pipeline(handlers=[ok], dead_letter=dl)
+        await pipeline.run("env-1")
+        self.assertEqual(seen, [])
+
+    async def test_dead_letter_exception_does_not_break_pipeline(self):
+        async def boom(env):
+            raise RuntimeError("nope")
+
+        async def broken_dl(env, name, exc):
+            raise ValueError("dead letter is itself broken")
+
+        async def later(env):
+            pass
+
+        pipeline = Pipeline(
+            handlers=[boom, later], dead_letter=broken_dl)
+        results = await pipeline.run("env-1")
+        self.assertEqual(results[0][0], "boom")
+        self.assertIsInstance(results[0][1], RuntimeError)
+        self.assertEqual(results[1], ("later", None))
+
+    async def test_sync_dead_letter_is_supported(self):
+        seen = []
+
+        async def boom(env):
+            raise RuntimeError("nope")
+
+        def dl(env, name, exc):
+            seen.append(name)
+
+        pipeline = Pipeline(handlers=[boom], dead_letter=dl)
+        await pipeline.run("env-1")
+        self.assertEqual(seen, ["boom"])
+
 
 class HandlersTest(unittest.IsolatedAsyncioTestCase):
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `Pipeline` currently logs and swallows any exception raised by a handler. That keeps unrelated handlers running, but it means a malformed envelope or a serializer bug can drop a message with no forensic trail.

## Current behavior before PR

- `Pipeline.run` catches `Exception`, logs it, and continues. There is no way for the operator to recover the offending envelope after the fact.
- `asyncio.CancelledError` already passes through correctly (it derives from `BaseException` on Python 3.8+), but the contract is undocumented and reads like an accidental property.

## Desired behavior after PR is merged

- New optional `dead_letter` constructor argument on `Pipeline`. Signature: `dead_letter(envelope, handler_name, exception)`. Async or sync. Invoked whenever a regular handler raises.
- Exceptions from the dead-letter sink itself are caught and logged but do not crash the pipeline (it is the last line of defense and must not be the cause of further data loss).
- Docstring on `Pipeline.run` now explicitly states that `asyncio.CancelledError` propagates and `amain` can cancel cleanly.
- 4 new tests cover the dead-letter contract: invoked-on-failure, not-invoked-on-success, broken-dead-letter, sync-callable support.