### PR TITLE
HL7 parser: preserve unmapped segments under metadata.unmapped_segments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #47 HL7 parser: preserve unmapped segments under metadata.unmapped_segments
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/tests/test_hl7_parser.py
+++ b/src/senaite/astm/tests/test_hl7_parser.py
@@ -216,6 +216,25 @@ class ParserRobustnessTest(unittest.TestCase):
         envelope = parse(lf_version)
         self.assertEqual(len(envelope.R), 20)
 
+    def test_unknown_segments_are_preserved_in_metadata(self):
+        # Inject a Z-segment (vendor-defined; not in SEGMENT_BUCKETS)
+        # and an unknown ABC segment. Both must surface under
+        # metadata.unmapped_segments instead of being dropped.
+        raw = load_fixture("hemoscreen_fresh_blood.hl7").decode("utf-8")
+        raw = raw.rstrip("\r") + "\rZDS|1|2|3\rABC|hello|world\r"
+        envelope = parse(raw)
+        extras = envelope.metadata.model_extra or {}
+        unmapped = extras.get("unmapped_segments", {})
+        self.assertIn("ZDS", unmapped)
+        self.assertIn("ABC", unmapped)
+        self.assertEqual(unmapped["ZDS"][0]["1"], "1")
+        self.assertEqual(unmapped["ABC"][0]["2"], "world")
+
+    def test_no_unmapped_segments_key_when_all_are_known(self):
+        envelope = parse(load_fixture("hemoscreen_fresh_blood.hl7"))
+        extras = envelope.metadata.model_extra or {}
+        self.assertNotIn("unmapped_segments", extras)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/senaite/astm/transports/hl7/parser.py
+++ b/src/senaite/astm/transports/hl7/parser.py
@@ -102,15 +102,21 @@ def parse(raw):
             "Failed to parse HL7 message: {}".format(exc)) from exc
 
     buckets = {bucket: [] for bucket in SEGMENT_BUCKETS.values()}
+    unmapped = {}
     for segment in message:
         name = str(segment[0])
         bucket = SEGMENT_BUCKETS.get(name)
         if bucket is None:
-            # Unknown segment — preserve as a generic dict under its
-            # own key so consumers can still see it without us
-            # silently dropping data.
+            unmapped.setdefault(name, []).append(
+                _segment_to_dict(segment))
             continue
         buckets[bucket].append(_segment_to_dict(segment))
 
-    metadata = Metadata(hl7=text.rstrip("\r"))
+    metadata_kwargs = {"hl7": text.rstrip("\r")}
+    if unmapped:
+        # Metadata accepts extras (extra="allow"). Surface segments
+        # the bucket map doesn't know about so consumers can decide
+        # what to do with them instead of us silently dropping them.
+        metadata_kwargs["unmapped_segments"] = unmapped
+    metadata = Metadata(**metadata_kwargs)
     return Envelope(metadata=metadata, **buckets)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The HL7 parser silently dropped any segment whose name wasn't in `SEGMENT_BUCKETS` (MSH/PID/OBR/OBX/NTE), despite a comment that said it should preserve them.

## Current behavior before PR

```
if bucket is None:
    # Unknown segment — preserve as a generic dict under its
    # own key so consumers can still see it without us
    # silently dropping data.
    continue
```

The comment is wrong: `continue` drops the segment. Z-segments and any other vendor-defined or unknown HL7 segment are lost without trace.

## Desired behavior after PR is merged

- Unknown segments are collected into a `{segment_name: [{...}, ...]}` dict and exposed on the envelope as `metadata.unmapped_segments` (via `Metadata.extra="allow"`).
- The key is only present when at least one unmapped segment was seen — consumers that don't care see no change in the envelope shape.
- Two new tests pin the behavior: one injects ZDS and ABC segments and asserts they round-trip; one asserts the key is absent when every segment is mapped.
- No envelope version bump: the schema docstring explicitly states only the buckets are versioned; per-segment shape is loose by design.