### PR TITLE
Synthetic ASTM adapters: extract framing dance into synthesize_session helper

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #48 Synthetic ASTM adapters: extract framing dance into synthesize_session helper
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/instruments/biomerieux_mini_vidas.py
+++ b/src/senaite/astm/instruments/biomerieux_mini_vidas.py
@@ -4,12 +4,10 @@ import re
 from datetime import datetime
 
 from senaite.astm import records
-from senaite.astm import utils
-from senaite.astm.constants import ENQ
-from senaite.astm.constants import EOT
 from senaite.astm.constants import NAK
 from senaite.astm.core.instrument import Instrument
 from senaite.astm.core.instrument import register_instrument
+from senaite.astm.transports.astm.synthesizer import synthesize_session
 from senaite.astm.fields import ComponentField, DateField
 from senaite.astm.fields import DateTimeField
 from senaite.astm.fields import TextField
@@ -120,13 +118,11 @@ class BiomerieuxMiniVidas(Instrument):
 
     def handle_raw_data(self, protocol, data):
         """Synthesise a complete ASTM session from a single non-ASTM
-        packet emitted by the miniVidas. Drives ``protocol`` directly.
+        packet emitted by the miniVidas.
         """
         parts = re.match(RAW_DATA_RX, data)
         if not parts:
             return NAK
-        if not protocol.in_transfer_state:
-            protocol.on_enq(ENQ)
 
         values = {k: (u(v) if v else "")
                   for k, v in parts.groupdict().items()}
@@ -148,14 +144,7 @@ class BiomerieuxMiniVidas(Instrument):
                 **values),
             fmt("5L|1|N{CR}{ETX}"),
         ]
-        messages = []
-        for frame in frames:
-            cs = utils.make_checksum(frame)
-            messages.append(
-                fmt("{STX}{frame}{cs}{CRLF}", frame=u(frame), cs=u(cs)))
-
-        protocol.messages = messages
-        protocol.on_eot(EOT)
+        synthesize_session(protocol, frames)
         return None
 
 

--- a/src/senaite/astm/instruments/spotchem_el.py
+++ b/src/senaite/astm/instruments/spotchem_el.py
@@ -4,18 +4,15 @@ import re
 from datetime import datetime
 
 from senaite.astm import records
-from senaite.astm import utils
-from senaite.astm.constants import ENQ
-from senaite.astm.constants import EOT
 from senaite.astm.constants import NAK
 from senaite.astm.core.instrument import Instrument
 from senaite.astm.core.instrument import register_instrument
+from senaite.astm.transports.astm.synthesizer import synthesize_session
 from senaite.astm.fields import ComponentField
 from senaite.astm.fields import DateTimeField
 from senaite.astm.fields import TextField
 from senaite.astm.mapping import Component
 from senaite.astm.utils import f as fmt
-from senaite.astm.utils import u
 
 VERSION = "1.0.0"
 # Supports SE1520
@@ -100,15 +97,10 @@ class SpotchemEL(Instrument):
     def handle_raw_data(self, protocol, data):
         """Synthesise a complete ASTM session from a single non-ASTM
         packet emitted by the Spotchem SE-1520.
-
-        Drives ``protocol`` directly: ENQ, queue the synthetic ASTM
-        frames, EOT.
         """
         parts = re.match(RAW_DATA_RX, data)
         if not parts:
             return NAK
-        if not protocol.in_transfer_state:
-            protocol.on_enq(ENQ)
 
         date = parts.group(1).decode("utf-8")
         time = parts.group(2).decode("utf-8")
@@ -142,14 +134,7 @@ class SpotchemEL(Instrument):
                 result=cl_result, unit=cl_unit, ts=timestamp),
             fmt("6L|1|N{CR}{ETX}"),
         ]
-        messages = []
-        for frame in frames:
-            cs = utils.make_checksum(frame)
-            messages.append(
-                fmt("{STX}{frame}{cs}{CRLF}", frame=u(frame), cs=u(cs)))
-
-        protocol.messages = messages
-        protocol.on_eot(EOT)
+        synthesize_session(protocol, frames)
         return None
 
 

--- a/src/senaite/astm/transports/astm/synthesizer.py
+++ b/src/senaite/astm/transports/astm/synthesizer.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Synthesize a full ASTM session from a list of frame templates.
+
+Used by adapters whose wire format is not valid ASTM
+(``biomerieux_mini_vidas``, ``spotchem_el``): the device sends a
+single non-ASTM packet, the adapter decodes it into a list of
+pre-numbered frame templates ending in ``{CR}{ETX}``, and this
+helper handles the shared boilerplate of:
+
+- starting the session with ENQ if the protocol is idle,
+- wrapping each frame in ``STX`` + checksum + ``CRLF``,
+- queueing them on ``protocol.messages``,
+- closing the session with EOT.
+
+This keeps the per-instrument code focused on its own decoding
+logic instead of repeating the framing dance.
+"""
+
+from senaite.astm import utils
+from senaite.astm.constants import ENQ, EOT
+
+
+def synthesize_session(protocol, frames):
+    """Drive ``protocol`` through a complete synthetic ASTM session.
+
+    :param protocol: An :class:`ASTMProtocol` instance.
+    :param frames: A list of pre-formatted frame templates (each
+        already contains its sequence number and ``{CR}{ETX}``).
+    """
+    if not protocol.in_transfer_state:
+        protocol.on_enq(ENQ)
+    messages = []
+    for frame in frames:
+        cs = utils.make_checksum(frame)
+        messages.append(
+            utils.f("{STX}{frame}{cs}{CRLF}",
+                    frame=utils.u(frame), cs=utils.u(cs)))
+    protocol.messages = messages
+    protocol.on_eot(EOT)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `biomerieux_mini_vidas` and `spotchem_el` adapters both end their `handle_raw_data` with the same ~12-line block: ENQ-if-idle, wrap each frame in `STX` + checksum + `CRLF`, push into `protocol.messages`, then drive `protocol.on_eot`. The two copies have already drifted slightly and will keep drifting every time a new non-ASTM adapter is added.

## Current behavior before PR

Each adapter open-codes the same framing dance and reaches into `protocol.messages` directly. The leaky coupling between adapter and transport state is repeated twice and is the kind of code that breaks the first time anyone tweaks the protocol.

## Desired behavior after PR is merged

- New module `transports/astm/synthesizer.py` with one function: `synthesize_session(protocol, frames)`.
- Each adapter just builds its list of pre-numbered frame templates ending in `{CR}{ETX}` and calls `synthesize_session(protocol, frames)`.
- ~22 LOC removed across the two adapters; the framing dance has one source of truth.
- Unused imports (`utils`, `ENQ`, `EOT`, sometimes `u`) are dropped from the adapters that no longer need them.