### PR TITLE
Lift validate_lims, frame_callback dispatch, and LIMS arg group into _runtime

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- #49 Lift validate_lims, frame_callback dispatch, and LIMS arg group into _runtime
 - #42 Wrapper: drop duplicate get_mapping call and chain ValueError with 'from exc'
 - #41 Document the HL7-over-MLLP transport and envelope bucket mapping
 - #38 Use microsecond precision in capture filenames

--- a/src/senaite/astm/cli/_runtime.py
+++ b/src/senaite/astm/cli/_runtime.py
@@ -24,6 +24,7 @@ import signal
 import sys
 
 from senaite.astm import logger
+from senaite.astm.core import lims
 
 LOGFILE_MAX_BYTES = 10 * 1024 * 1024
 LOGFILE_BACKUP_COUNT = 5
@@ -120,3 +121,84 @@ async def _run(payload, pipeline):
         await pipeline.run(payload)
     except Exception as exc:
         logger.error("Pipeline run failed: %r", exc)
+
+
+def make_frame_callback(loop, pipeline, task_set, to_envelope):
+    """Build a transport-agnostic frame callback.
+
+    The ASTM and HL7 transports differ only in how their per-session
+    payload is turned into an :class:`Envelope`. ``to_envelope`` does
+    that conversion; the rest (tracked-task scheduling, parse-error
+    isolation, pipeline dispatch) is shared.
+
+    :param to_envelope: Callable taking the transport payload (a list
+        of ASTM frames or raw HL7 bytes) and returning an
+        :class:`Envelope`. May raise — failures are logged and the
+        envelope is dropped, but the transport stays up.
+    """
+    def frame_callback(client, payload):
+        task = loop.create_task(
+            _run_with_envelope(client, payload, pipeline, to_envelope))
+        task_set.add(task)
+        task.add_done_callback(task_set.discard)
+    return frame_callback
+
+
+async def _run_with_envelope(client, payload, pipeline, to_envelope):
+    try:
+        envelope = to_envelope(payload)
+    except Exception as exc:
+        logger.error(
+            "Failed to build envelope from %s: %r", client, exc)
+        return
+    await pipeline.run(envelope)
+
+
+def add_lims_arg_group(parser, default_consumer):
+    """Append the shared SENAITE LIMS option group to ``parser``.
+
+    All transports take the same connection / auth / retry flags;
+    only the default push-consumer name differs (the ASTM and HL7
+    transports are wired to different consumers in SENAITE.CORE).
+    """
+    group = parser.add_argument_group("SENAITE LIMS")
+    group.add_argument(
+        "-u", "--url", type=str,
+        help="SENAITE URL address including username and password "
+             "in the format: "
+             "http(s)://<user>:<password>@<senaite_url>. Without "
+             "--url the server runs in capture-only mode.")
+    group.add_argument(
+        "-c", "--consumer", type=str, default=default_consumer,
+        help="SENAITE push consumer interface")
+    group.add_argument(
+        "-m", "--message-format", type=str, default="json",
+        help="Message format to send to SENAITE.")
+    group.add_argument(
+        "-r", "--retries", type=int, default=3,
+        help="Number of push attempts on transient failures. Only "
+             "applies when --url is set.")
+    group.add_argument(
+        "-d", "--delay", type=int, default=5,
+        help="Seconds between push retries. Only applies when "
+             "--url is set.")
+    return group
+
+
+def validate_lims(url):
+    """Authenticate against SENAITE and return the session, or
+    ``None`` when ``url`` is empty.
+
+    Exits the process with status -1 on auth failure so the server
+    never starts up half-configured.
+    """
+    if not url:
+        return None
+    session = lims.Session(url)
+    logger.info("Checking connection to SENAITE ...")
+    try:
+        session.auth()
+    except lims.SenaiteError as exc:
+        logger.error("Could not connect to SENAITE: {}".format(exc))
+        raise SystemExit(-1)
+    return session

--- a/src/senaite/astm/cli/astm_server.py
+++ b/src/senaite/astm/cli/astm_server.py
@@ -17,7 +17,6 @@ import os
 
 from senaite.astm import logger
 from senaite.astm.cli import _runtime
-from senaite.astm.core import lims
 from senaite.astm.core.lims import LimsPushHandler
 from senaite.astm.core.output import DiskCaptureHandler
 from senaite.astm.core.pipeline import Pipeline
@@ -32,8 +31,6 @@ def build_arg_parser():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     astm_group = parser.add_argument_group("ASTM SERVER")
-    lims_group = parser.add_argument_group("SENAITE LIMS")
-
     astm_group.add_argument(
         "-l", "--listen", type=str, default="0.0.0.0",
         help="Listen IP address")
@@ -49,28 +46,8 @@ def build_arg_parser():
         help="Seconds to wait for in-flight handler tasks to "
              "finish before forcefully cancelling them on shutdown.")
 
-    lims_group.add_argument(
-        "-u", "--url", type=str,
-        help="SENAITE URL address including username and password in "
-             "the format: http(s)://<user>:<password>@<senaite_url>")
-    lims_group.add_argument(
-        "-c", "--consumer", type=str,
-        default="senaite.core.lis2a.import",
-        help="SENAITE push consumer interface")
-    lims_group.add_argument(
-        "-m", "--message-format", type=str, default="json",
-        help="Message format to send to SENAITE. "
-             "Allowed formats: 'astm', 'lis2a', 'json'.")
-    lims_group.add_argument(
-        "-r", "--retries", type=int, default=3,
-        help="Number of attempts of reconnection when SENAITE "
-             "instance is not reachable. Only has effect when "
-             "argument --url is set")
-    lims_group.add_argument(
-        "-d", "--delay", type=int, default=5,
-        help="Time delay in seconds between retries when SENAITE "
-             "instance is not reachable. Only has effect when "
-             "argument --url is set")
+    _runtime.add_lims_arg_group(
+        parser, default_consumer="senaite.core.lis2a.import")
 
     parser.add_argument(
         "-v", "--verbose", action="store_true",
@@ -80,19 +57,6 @@ def build_arg_parser():
         help="Path to store log files")
 
     return parser
-
-
-def validate_lims(url):
-    if not url:
-        return None
-    session = lims.Session(url)
-    logger.info("Checking connection to SENAITE ...")
-    try:
-        session.auth()
-    except lims.SenaiteError as exc:
-        logger.error("Could not connect to SENAITE: {}".format(exc))
-        raise SystemExit(-1)
-    return session
 
 
 def build_pipeline(args, session):
@@ -116,23 +80,9 @@ def make_frame_callback(loop, pipeline, task_set):
     The ASTM transport hands us a *list of frames* per session; we
     wrap them into an :class:`Envelope` before running the pipeline.
     """
-    def frame_callback(client, frames):
-        task = loop.create_task(
-            _process_frames(client, frames, pipeline))
-        task_set.add(task)
-        task.add_done_callback(task_set.discard)
-    return frame_callback
-
-
-async def _process_frames(client, frames, pipeline):
-    try:
-        envelope = Wrapper(frames).to_envelope()
-    except Exception as exc:
-        logger.error(
-            "Failed to wrap %d frames from %s: %r",
-            len(frames), client, exc)
-        return
-    await pipeline.run(envelope)
+    return _runtime.make_frame_callback(
+        loop, pipeline, task_set,
+        to_envelope=lambda frames: Wrapper(frames).to_envelope())
 
 
 async def amain(args, stop_event=None):
@@ -180,6 +130,7 @@ LOGFILE_BACKUP_COUNT = _runtime.LOGFILE_BACKUP_COUNT
 DEFAULT_SHUTDOWN_GRACE_SECONDS = _runtime.DEFAULT_SHUTDOWN_GRACE_SECONDS
 configure_logging = _runtime.configure_logging
 validate_output = _runtime.validate_output
+validate_lims = _runtime.validate_lims
 _drain_tasks = _runtime.drain_tasks
 
 
@@ -189,7 +140,7 @@ def main():
 
     _runtime.configure_logging(args)
     _runtime.validate_output(args.output)
-    args.session = validate_lims(args.url)
+    args.session = _runtime.validate_lims(args.url)
 
     try:
         asyncio.run(amain(args))

--- a/src/senaite/astm/cli/hl7_server.py
+++ b/src/senaite/astm/cli/hl7_server.py
@@ -18,7 +18,6 @@ import os
 
 from senaite.astm import logger
 from senaite.astm.cli import _runtime
-from senaite.astm.core import lims
 from senaite.astm.core.lims import LimsPushHandler
 from senaite.astm.core.output import DiskCaptureHandler
 from senaite.astm.core.pipeline import Pipeline
@@ -39,8 +38,6 @@ def build_arg_parser():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     hl7_group = parser.add_argument_group("HL7 SERVER")
-    lims_group = parser.add_argument_group("SENAITE LIMS")
-
     hl7_group.add_argument(
         "-l", "--listen", type=str, default="0.0.0.0",
         help="Listen IP address")
@@ -57,27 +54,8 @@ def build_arg_parser():
         help="Seconds to wait for in-flight handler tasks to "
              "finish before forcefully cancelling them on shutdown.")
 
-    lims_group.add_argument(
-        "-u", "--url", type=str,
-        help="SENAITE URL address including username and password in "
-             "the format: http(s)://<user>:<password>@<senaite_url>. "
-             "Without --url the server runs in capture-only mode.")
-    lims_group.add_argument(
-        "-c", "--consumer", type=str,
-        default="senaite.core.hl7.import",
-        help="SENAITE push consumer interface")
-    lims_group.add_argument(
-        "-m", "--message-format", type=str, default="json",
-        help="Message format to send to SENAITE. "
-             "Allowed formats: 'json', 'hl7'.")
-    lims_group.add_argument(
-        "-r", "--retries", type=int, default=3,
-        help="Number of push attempts on transient failures. Only "
-             "applies when --url is set.")
-    lims_group.add_argument(
-        "-d", "--delay", type=int, default=5,
-        help="Seconds between push retries. Only applies when "
-             "--url is set.")
+    _runtime.add_lims_arg_group(
+        parser, default_consumer="senaite.core.hl7.import")
 
     parser.add_argument(
         "-v", "--verbose", action="store_true",
@@ -89,17 +67,7 @@ def build_arg_parser():
     return parser
 
 
-def validate_lims(url):
-    if not url:
-        return None
-    session = lims.Session(url)
-    logger.info("Checking connection to SENAITE ...")
-    try:
-        session.auth()
-    except lims.SenaiteError as exc:
-        logger.error("Could not connect to SENAITE: {}".format(exc))
-        raise SystemExit(-1)
-    return session
+validate_lims = _runtime.validate_lims
 
 
 def build_pipeline(args, session):
@@ -128,22 +96,8 @@ def make_frame_callback(loop, pipeline, task_set):
     We parse them into an envelope and schedule a tracked task so
     shutdown can wait for in-flight handlers.
     """
-    def frame_callback(client, hl7_bytes):
-        task = loop.create_task(
-            _process(client, hl7_bytes, pipeline))
-        task_set.add(task)
-        task.add_done_callback(task_set.discard)
-    return frame_callback
-
-
-async def _process(client, hl7_bytes, pipeline):
-    try:
-        envelope = parse_hl7(hl7_bytes)
-    except Exception as exc:
-        logger.error(
-            "Failed to parse HL7 message from %s: %r", client, exc)
-        return
-    await pipeline.run(envelope)
+    return _runtime.make_frame_callback(
+        loop, pipeline, task_set, to_envelope=parse_hl7)
 
 
 async def amain(args, stop_event=None):
@@ -185,7 +139,7 @@ def main():
 
     _runtime.configure_logging(args)
     _runtime.validate_output(args.output)
-    args.session = validate_lims(args.url)
+    args.session = _runtime.validate_lims(args.url)
 
     try:
         asyncio.run(amain(args))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`cli/astm_server.py` and `cli/hl7_server.py` had three near-identical code blocks: the SENAITE LIMS argparse group (5 options each), `validate_lims(url)`, and the tracked frame-callback dispatcher. The only real difference between the two `make_frame_callback`s is how the per-session payload is turned into an `Envelope` — `Wrapper(frames).to_envelope()` for ASTM vs `parse_hl7(bytes)` for HL7.

## Current behavior before PR

Both CLIs carry their own copies. Drift is silent — and indeed the two `make_frame_callback`s already log slightly different error messages on parse failure.

## Desired behavior after PR is merged

- `_runtime.add_lims_arg_group(parser, default_consumer)` — parametrised on the default push-consumer name (ASTM uses `senaite.core.lis2a.import`, HL7 uses `senaite.core.hl7.import`); everything else is shared.
- `_runtime.validate_lims(url)` — moved verbatim. Each CLI re-exports it as a module-level alias for backwards-compat with existing tests.
- `_runtime.make_frame_callback(loop, pipeline, task_set, to_envelope)` — generic. Each CLI passes the appropriate `to_envelope` callable.
- Both CLI modules shrink by ~50 LOC each. The full test suite stays green.