### PR TITLE
Quiet empty-session disconnects: log TCP-probe drops at DEBUG, keep WARNING for mid-session cuts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- Quiet empty-session disconnects: log TCP-probe drops at DEBUG, keep WARNING for mid-session cuts
 - #49 Lift validate_lims, frame_callback dispatch, and LIMS arg group into _runtime
 - #48 Synthetic ASTM adapters: extract framing dance into synthesize_session helper
 - #47 HL7 parser: preserve unmapped segments under metadata.unmapped_segments

--- a/src/senaite/astm/tests/test_astm_protocol.py
+++ b/src/senaite/astm/tests/test_astm_protocol.py
@@ -85,3 +85,34 @@ class ASTMProtocolTest(ASTMTestBase):
 
         # Protocol should be no longer in transfer state
         self.assertFalse(self.protocol.in_transfer_state)
+
+    def test_empty_session_disconnect_logs_at_debug(self):
+        """A TCP probe (connect + close, no data) must not fire a
+        WARNING — it's routine noise from Zabbix / load balancers."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+
+        with self.assertLogs("senaite.astm", level="DEBUG") as cm:
+            self.protocol.connection_lost(None)
+
+        levels = [r.levelname for r in cm.records]
+        messages = [r.getMessage() for r in cm.records]
+        self.assertNotIn("WARNING", levels)
+        self.assertTrue(
+            any("without data" in m for m in messages),
+            "expected an empty-session debug line, got %r" % messages,
+        )
+
+    def test_mid_session_disconnect_logs_at_warning(self):
+        """A real session cut mid-message stays at WARNING so it
+        remains visible in operational logs."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+        # Simulate a partial session: ENQ received, frames buffered.
+        self.protocol.in_transfer_state = True
+        self.protocol.messages = [b"1H|"]
+
+        with self.assertLogs("senaite.astm", level="DEBUG") as cm:
+            self.protocol.connection_lost(None)
+
+        self.assertIn("WARNING", [r.levelname for r in cm.records])

--- a/src/senaite/astm/tests/test_hl7_protocol.py
+++ b/src/senaite/astm/tests/test_hl7_protocol.py
@@ -62,6 +62,31 @@ class BuildAckTest(unittest.TestCase):
         self.assertIn(b"MSA|AA|", ack)
 
 
+class HL7ConnectionLostTest(unittest.TestCase):
+    """Empty-buffer disconnects (TCP probes) must not log WARNING."""
+
+    def _make_protocol(self):
+        proto = HL7Protocol()
+        proto.client = "127.0.0.1:54321"
+        return proto
+
+    def test_empty_buffer_disconnect_logs_at_debug(self):
+        proto = self._make_protocol()
+        with self.assertLogs("senaite.astm", level="DEBUG") as cm:
+            proto.connection_lost(None)
+        self.assertNotIn(
+            "WARNING", [r.levelname for r in cm.records])
+        self.assertTrue(
+            any("without data" in r.getMessage() for r in cm.records))
+
+    def test_buffered_data_disconnect_logs_at_warning(self):
+        proto = self._make_protocol()
+        proto.buffer = b"MSH|^~\\&|partial"
+        with self.assertLogs("senaite.astm", level="DEBUG") as cm:
+            proto.connection_lost(None)
+        self.assertIn("WARNING", [r.levelname for r in cm.records])
+
+
 class HL7ServerTest(unittest.IsolatedAsyncioTestCase):
 
     PORT = 7985

--- a/src/senaite/astm/transports/astm/protocol.py
+++ b/src/senaite/astm/transports/astm/protocol.py
@@ -71,8 +71,24 @@ class ASTMProtocol(asyncio.Protocol):
         logger.debug("Connection from {!s}".format(self.client))
 
     def connection_lost(self, ex):
-        logger.warning("Lost connection for {!s}".format(self.client))
+        # Distinguish "client closed without sending data" (typical
+        # TCP health probe from Zabbix / load balancer / k8s liveness
+        # check) from "an in-flight session was cut mid-message". The
+        # former is routine noise; the latter is operationally
+        # interesting and stays at WARNING.
+        if self._session_was_empty():
+            logger.debug(
+                "Connection closed without data from %s", self.client)
+        else:
+            logger.warning(
+                "Lost connection for %s", self.client)
         self.close_connection()
+
+    def _session_was_empty(self):
+        """True when nothing was received between connect and close."""
+        return (not self.in_transfer_state
+                and not self.chunks
+                and not self.messages)
 
     def data_received(self, data):
         logger.debug("-> Data received from {!s}: {!r}".format(

--- a/src/senaite/astm/transports/hl7/protocol.py
+++ b/src/senaite/astm/transports/hl7/protocol.py
@@ -113,7 +113,17 @@ class HL7Protocol(asyncio.Protocol):
         logger.debug("HL7 connection from %s", self.client)
 
     def connection_lost(self, ex):
-        logger.warning("Lost HL7 connection for %s", self.client)
+        # Empty-buffer disconnect = TCP probe (Zabbix, load balancer,
+        # etc.). Log at DEBUG so the routine churn doesn't drown out
+        # the operationally-interesting case of a real client
+        # dropping mid-message.
+        if not self.buffer:
+            logger.debug(
+                "HL7 connection closed without data from %s", self.client)
+        else:
+            logger.warning(
+                "Lost HL7 connection for %s with %d byte(s) buffered",
+                self.client, len(self.buffer))
         self.buffer = b""
 
     def data_received(self, data):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Production ASTM/HL7 server logs are full of WARNING-level "Lost connection" lines that are actually routine TCP health probes — a Zabbix monitor (or any LB / k8s liveness check) connects, doesn't send a byte, and closes. The current `connection_lost` emits the same WARNING regardless of whether the peer was a real instrument cut mid-message or a probe.

Sample from a live deployment (probes every ~25 s):

```
[server.log] 11:03:24,548 DEBUG    Connection from 127.0.0.1:52198
[server.log] 11:03:24,549 WARNING  Lost connection for 127.0.0.1:52198
[server.log] 11:03:48,693 DEBUG    Connection from 127.0.0.1:54796
[server.log] 11:03:48,693 WARNING  Lost connection for 127.0.0.1:54796
```

The 1 ms delta between connect and close is the signature.

## Current behavior before PR

`ASTMProtocol.connection_lost` and `HL7Protocol.connection_lost` both log unconditionally at WARNING. A real instrument dropping mid-message and a 0-byte port probe produce identical log lines.

## Desired behavior after PR is merged

Both protocols distinguish "client closed without sending data" (DEBUG — routine, expected from health probes) from "session cut while data was in flight" (WARNING — operationally interesting, stays visible).

- `ASTMProtocol`: `_session_was_empty()` is true when `in_transfer_state`, `chunks`, and `messages` are all empty/false.
- `HL7Protocol`: empty buffer means no bytes were ever received. The non-empty WARNING also reports how many bytes were buffered so the operator sees how far the message had progressed.

Four new tests pin the contract (empty-session → no WARNING; mid-session/buffered → WARNING) for both transports.