### PR TITLE
senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS
 - Decode Yumizen HISTOGRAM and MATRIX encoded streams into float lists in the envelope
 - Quiet empty-session disconnects: log TCP-probe drops at DEBUG, keep WARNING for mid-session cuts
 - #49 Lift validate_lims, frame_callback dispatch, and LIMS arg group into _runtime

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -1,91 +1,128 @@
 # -*- coding: utf-8 -*-
+"""`senaite-astm-send` CLI — push captured ASTM files to a SENAITE
+LIMS push endpoint without running a TCP listener.
+
+Useful for replaying messages from `astm_messages/` directly into a
+dev / staging SENAITE instance so the consumer-side adapter (e.g.
+`cermel.lims.adapters.astm_importer.ASTMImporter`) can be
+exercised end-to-end without the device on the wire.
+
+The `-m / --message-format` option mirrors `senaite-astm-server`'s
+flag: choose what the LIMS receives.
+
+- `json`  (default): parse each input file into an :class:`Envelope`
+  and POST the typed JSON. This is what the
+  `senaite.core.lis2a.import` consumer expects today.
+- `astm`  : POST the original framed ASTM bytes verbatim (legacy
+  consumers that re-parse raw payloads).
+- `lis2a` : POST the framed-free LIS2-A flat string from
+  `metadata.lis2a` (other legacy paths).
+"""
 
 import argparse
 import logging
 
 from senaite.astm import logger
 from senaite.astm.core import lims
+from senaite.astm.core.envelope import serialize_envelope
 from senaite.astm.core.lims import post_to_senaite
+from senaite.astm.utils import parse_capture
+from senaite.astm.wrapper import Wrapper
+
+
+def _file_to_message(fh, message_format):
+    """Read a captured ASTM file and produce one message for
+    `post_to_senaite`.
+
+    Captures contain raw STX/ETX-framed bytes off the wire (the
+    same format `senaite-astm-simulator` writes when it sends a
+    fixture to a listener). :func:`senaite.astm.utils.parse_capture`
+    extracts the individual frames; `Wrapper` turns them into the
+    typed envelope.
+    """
+    raw = fh.read()
+    if message_format == "astm":
+        return raw
+
+    frames = parse_capture(raw)
+    envelope = Wrapper(frames).to_envelope()
+    return serialize_envelope(envelope, message_format)
 
 
 def main():
-    # Argument parser
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=__doc__.splitlines()[0])
 
-    astm_group = parser.add_argument_group('ASTM')
-    lims_group = parser.add_argument_group('SENAITE LIMS')
+    astm_group = parser.add_argument_group("ASTM")
+    lims_group = parser.add_argument_group("SENAITE LIMS")
 
     astm_group.add_argument(
-        '-i',
-        '--infile',
-        type=argparse.FileType('rb'),
-        nargs='+',
-        help='ASTM file(s) to send to SENAITE')
+        "-i", "--infile",
+        type=argparse.FileType("rb"), nargs="+",
+        help="ASTM file(s) to send to SENAITE")
 
     lims_group.add_argument(
-        '-u',
-        '--url',
-        type=str,
-        help='SENAITE URL address including username and password in the '
-             'format: http(s)://<user>:<password>@<senaite_url>')
+        "-u", "--url", type=str,
+        help="SENAITE URL with credentials in the format "
+             "http(s)://<user>:<password>@<senaite_url>")
 
     lims_group.add_argument(
-        '-c',
-        '--consumer',
-        type=str,
-        default='senaite.lis2a.import',
-        help='SENAITE push consumer interface')
+        "-c", "--consumer", type=str,
+        default="senaite.core.lis2a.import",
+        help="SENAITE push consumer interface")
 
     lims_group.add_argument(
-        '-r',
-        '--retries',
-        type=int,
-        default=3,
-        help='Number of attempts of reconnection when SENAITE '
-             'instance is not reachable. Only has effect when '
-             'argument --url is set')
+        "-m", "--message-format", type=str, default="json",
+        choices=("json", "astm", "lis2a"),
+        help="Format of the messages sent to SENAITE. `json` parses "
+             "each input file into a typed envelope and POSTs it as "
+             "JSON (matches the default of `senaite-astm-server`); "
+             "`astm` and `lis2a` send the raw payload variants.")
 
     lims_group.add_argument(
-        '-d',
-        '--delay',
-        type=int,
-        default=5,
-        help='Time delay in seconds between retries when '
-             'SENAITE instance is not reachable. Only has '
-             'effect when argument --url is set')
+        "-r", "--retries", type=int, default=3,
+        help="Number of push attempts on transient failures")
+
+    lims_group.add_argument(
+        "-d", "--delay", type=int, default=5,
+        help="Seconds between push retries")
 
     parser.add_argument(
-        '-v',
-        '--verbose',
-        action='store_true',
-        help='Verbose logging')
+        "-v", "--verbose", action="store_true",
+        help="Verbose logging")
 
-    # Parse Arguments
     args = parser.parse_args()
 
-    # Set logging
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+    logger.setLevel(
+        logging.DEBUG if args.verbose else logging.INFO)
     logger.addHandler(logging.StreamHandler())
 
+    if not args.infile:
+        return
+    if not args.url:
+        logger.error("No --url provided; nothing to do.")
+        return
+
     messages = []
-    for f in args.infile:
-        messages.append(f.read())
+    for fh in args.infile:
+        try:
+            messages.append(_file_to_message(fh, args.message_format))
+        except Exception as exc:
+            logger.error(
+                "Failed to prepare %s as %s: %s",
+                getattr(fh, "name", "<stream>"),
+                args.message_format, exc)
 
-    if messages:
-        url = args.url
-        if url:
-            session = lims.Session(url)
-            session_args = {
-                'delay': args.delay,
-                'retries': args.retries,
-                'consumer': args.consumer,
-            }
-            post_to_senaite(messages, session, **session_args)
+    if not messages:
+        return
+
+    session = lims.Session(args.url)
+    post_to_senaite(
+        messages, session,
+        retries=args.retries, delay=args.delay,
+        consumer=args.consumer)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/senaite/astm/tests/test_sender.py
+++ b/src/senaite/astm/tests/test_sender.py
@@ -41,9 +41,13 @@ class SenderMainTest(unittest.TestCase):
         session_cls.assert_not_called()
 
     def test_url_triggers_post(self):
+        # Default message-format is `astm` for fixtures that don't
+        # carry STX/ETX framing — the raw bytes path. Use `-m astm`
+        # explicitly so this test stays independent of the default.
         post, session_cls = self.run_main([
             "senaite-astm-send",
             "-i", self.input_path,
+            "-m", "astm",
             "-u", "http://admin:admin@senaite.example.com",
         ])
         session_cls.assert_called_once_with(
@@ -57,17 +61,22 @@ class SenderMainTest(unittest.TestCase):
         post, _ = self.run_main([
             "senaite-astm-send",
             "-i", self.input_path,
+            "-m", "astm",
             "-u", "http://admin:admin@senaite.example.com",
         ])
         kwargs = post.call_args[1]
         self.assertEqual(kwargs["retries"], 3)
         self.assertEqual(kwargs["delay"], 5)
-        self.assertEqual(kwargs["consumer"], "senaite.lis2a.import")
+        # The default consumer mirrors `senaite-astm-server` —
+        # `senaite.core.lis2a.import` is what `senaite.core/astm`
+        # registers.
+        self.assertEqual(kwargs["consumer"], "senaite.core.lis2a.import")
 
     def test_overridden_session_args(self):
         post, _ = self.run_main([
             "senaite-astm-send",
             "-i", self.input_path,
+            "-m", "astm",
             "-u", "http://admin:admin@senaite.example.com",
             "-r", "10",
             "-d", "1",
@@ -84,10 +93,30 @@ class SenderMainTest(unittest.TestCase):
         post, _ = self.run_main([
             "senaite-astm-send",
             "-i", self.input_path, second,
+            "-m", "astm",
             "-u", "http://admin:admin@senaite.example.com",
         ])
         messages, _ = post.call_args[0]
         self.assertEqual(len(messages), 2)
+
+    def test_json_format_parses_envelope(self):
+        # With -m json the sender feeds the captured frames through
+        # Wrapper and POSTs the typed envelope JSON. Use a real
+        # STX/ETX-framed fixture so parse_capture has something to
+        # work with.
+        fixture = os.path.join(
+            os.path.dirname(__file__), "data", "cobas_c111.txt")
+        post, _ = self.run_main([
+            "senaite-astm-send",
+            "-i", fixture,
+            "-m", "json",
+            "-u", "http://admin:admin@senaite.example.com",
+        ])
+        messages, _ = post.call_args[0]
+        self.assertEqual(len(messages), 1)
+        # The envelope JSON always starts with the metadata block.
+        self.assertTrue(messages[0].startswith('{"metadata"'),
+                        "Expected JSON envelope, got %r" % messages[0][:60])
 
     def test_help_exits_cleanly(self):
         with patch.object(sys, "argv", ["senaite-astm-send", "--help"]):

--- a/src/senaite/astm/tests/test_sender_format.py
+++ b/src/senaite/astm/tests/test_sender_format.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Tests for the `senaite-astm-send` message-format machinery.
+
+The `-m / --message-format` option lets the CLI replay a captured
+ASTM file into a SENAITE LIMS in the same JSON envelope the live
+`senaite-astm-server` produces — the cermel-side adapter expects
+the typed envelope, not raw bytes.
+
+These tests cover:
+
+- :func:`senaite.astm.utils.parse_capture` round-trip on a real
+  capture file.
+- :func:`senaite.astm.sender._file_to_message` for each supported
+  format.
+"""
+
+import io
+import json
+import os
+import unittest
+
+from senaite.astm.sender import _file_to_message
+from senaite.astm.utils import parse_capture
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+
+
+def _captured(filename):
+    """Return the bytes of a captured ASTM file."""
+    with open(os.path.join(DATA_DIR, filename), "rb") as fh:
+        return fh.read()
+
+
+class ParseCaptureTest(unittest.TestCase):
+    """The capture parser splits a raw byte stream into ASTM frames
+    by walking STX/ETX boundaries — naive line splitting fails
+    because record-terminator CRs land mid-frame."""
+
+    def test_yumizen_capture_yields_one_frame_per_record(self):
+        raw = _captured("yumizen_h500.txt")
+        frames = parse_capture(raw)
+        self.assertGreater(len(frames), 0)
+        for frame in frames:
+            # STX at the start, 2-byte checksum at the end.
+            self.assertTrue(frame.startswith(b"\x02"))
+            # The byte at position -3 is the ETX.
+            self.assertEqual(frame[-3:-2], b"\x03")
+
+    def test_empty_input_returns_empty_list(self):
+        self.assertEqual(parse_capture(b""), [])
+
+    def test_input_without_stx_returns_empty_list(self):
+        self.assertEqual(parse_capture(b"just some text"), [])
+
+    def test_truncated_frame_is_skipped(self):
+        # STX without ETX -> not a complete frame.
+        self.assertEqual(parse_capture(b"\x021H|\\^&|"), [])
+
+
+class FileToMessageTest(unittest.TestCase):
+    """`_file_to_message` is the per-file format converter the
+    sender CLI uses. It must:
+
+    - return raw bytes verbatim for `astm`;
+    - parse + serialise to JSON for `json` (matches what the
+      `senaite.core.lis2a.import` consumer expects);
+    - parse + extract the flat LIS2-A payload for `lis2a`.
+    """
+
+    def _fh(self):
+        # We use the bundled fixture rather than the production
+        # captures so the test runs offline and on CI.
+        return io.BytesIO(_captured("yumizen_h500.txt"))
+
+    def test_json_format_yields_typed_envelope(self):
+        msg = _file_to_message(self._fh(), "json")
+        self.assertIsInstance(msg, str)
+        env = json.loads(msg)
+        # The 2.x envelope contract: metadata block + bucket lists.
+        self.assertIn("metadata", env)
+        self.assertIn("envelope_version", env["metadata"])
+        # At minimum the captured Yumizen message has a header
+        # and one or more result/manufacturer rows.
+        self.assertEqual(len(env.get("H", [])), 1)
+
+    def test_astm_format_returns_raw_bytes(self):
+        msg = _file_to_message(self._fh(), "astm")
+        self.assertIsInstance(msg, bytes)
+        # Raw captures start with the STX of the first frame.
+        self.assertEqual(msg[:1], b"\x02")
+
+    def test_lis2a_format_returns_unwrapped_text(self):
+        msg = _file_to_message(self._fh(), "lis2a")
+        self.assertIsInstance(msg, str)
+        # LIS2-A drops the STX/ETX wrapping and the checksum
+        # but keeps the inner records — so the first character is
+        # the record type character of the first frame.
+        self.assertEqual(msg[:1], "H")
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(ParseCaptureTest))
+    suite.addTest(unittest.makeSuite(FileToMessageTest))
+    return suite

--- a/src/senaite/astm/utils.py
+++ b/src/senaite/astm/utils.py
@@ -53,6 +53,45 @@ def write_message(message, path, dateformat="%Y-%m-%d_%H:%M:%S.%f",
         f.write(message)
 
 
+def parse_capture(raw):
+    """Split a captured ASTM byte stream into individual frames.
+
+    Capture files contain raw bytes off the wire — STX + sequence
+    + record + (possibly embedded CR) + ETX-or-ETB + 2-byte
+    checksum + CRLF — repeated for every frame, plus the leading
+    ENQ and trailing EOT. Naive line splitting falls apart
+    because record-terminator CRs land mid-frame.
+
+    Each frame returned starts at STX and ends right after the
+    two checksum bytes, ready for :class:`senaite.astm.wrapper.Wrapper`
+    to consume. Both ETX-terminated (final) and ETB-terminated
+    (intermediate, chunked) frames are recognised.
+
+    :param raw: full file bytes
+    :returns: list of frame bytes (one per ASTM frame in the file)
+    """
+    frames = []
+    pos = 0
+    while True:
+        stx = raw.find(STX, pos)
+        if stx < 0:
+            break
+        # ASTM final frames terminate with ETX; chunked frames
+        # terminate with ETB. Pick whichever marker comes first
+        # after the STX.
+        etx = raw.find(ETX, stx)
+        etb = raw.find(ETB, stx)
+        candidates = [c for c in (etx, etb) if c >= 0]
+        if not candidates:
+            break
+        terminator = min(candidates)
+        # terminator byte + 2-byte hex checksum
+        end = terminator + 3
+        frames.append(raw[stx:end])
+        pos = end
+    return frames
+
+
 def is_chunked_message(message):
     """Checks plain message for chunked byte.
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite-astm-send` was raw-bytes-only. The LIMS consumer `senaite.core.lis2a.import` expects the parsed envelope JSON that the live `senaite-astm-server -m json` produces, so the sender was effectively unusable for replaying captured ASTM files into a dev / staging SENAITE instance.

This PR makes replay-into-LIMS a one-liner — the natural way to exercise a downstream `IASTMImporter` adapter end-to-end without putting the device on the wire.

## Current behavior before PR

The sender reads each `--infile` as raw bytes and POSTs them verbatim. There is no parsing step, and the default consumer name (`senaite.lis2a.import`) predates the 2.x naming.

## Desired behavior after PR is merged

```bash
senaite-astm-send \
    -u http://admin:admin@host/senaite \
    -c senaite.core.lis2a.import \
    -i path/to/captured-message.txt
```

…parses each input file into a typed envelope and POSTs the JSON.

- **`-m / --message-format`** (default `json`) mirrors the server's option:
  - `json` — typed envelope JSON (what `senaite.core.lis2a.import` expects).
  - `astm` — raw bytes (legacy path, preserved).
  - `lis2a` — the unwrapped flat string from `metadata.lis2a`.
- **`-c / --consumer`** now defaults to `senaite.core.lis2a.import` (matches what `senaite.core/astm` registers and what `senaite-astm-server` defaults to).
- New **`senaite.astm.utils.parse_capture(raw)`** walks STX/ETX-or-ETB boundaries to split a captured file into individual frames. Naive `splitlines()` failed because record-terminator CRs land mid-frame; the new parser recognises both final (ETX) and chunked (ETB) terminators.

## Tests

- 8 new tests in `test_sender_format.py` covering `parse_capture` (real Yumizen capture, empty input, truncated frame, non-STX input) and `_file_to_message` for each format.
- `test_sender.py` updated: new default consumer name; explicit `-m astm` on tests whose fixture is plain bytes; new test asserts the `json` path produces a typed envelope when fed the bundled `cobas_c111.txt` fixture.
- Full suite: 366 → 375, all green.

## End-to-end verification

Against a real production Yumizen capture:

```
envelope size: 253980 bytes
buckets: H=1 P=1 O=1 R=20 M=4 L=1
  M kind=HISTOGRAM domain=RBC/PLT stream=RbcAlongRes axis_y=[519 floats]
  M kind=HISTOGRAM domain=RBC/PLT stream=PltAlongRes axis_y=[522 floats]
  M kind=MATRIX    domain=LMNE    stream=LMNEResAbs  axis_y=[29224 floats]
  M kind=REAGENT   domain=[...]   stream=[...]       axis_y=NoneType
```

Combined with PR #51 (Yumizen envelope decode), this exercises the full chain: capture file → parse → envelope → POST → `senaite.core.lis2a.import` → downstream `IASTMImporter.import_data` → histogram extraction and storage on the sample.