### PR TITLE
senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS
 - Decode Yumizen HISTOGRAM and MATRIX encoded streams into float lists in the envelope
 - Quiet empty-session disconnects: log TCP-probe drops at DEBUG, keep WARNING for mid-session cuts

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -27,10 +27,11 @@ from senaite.astm.core import lims
 from senaite.astm.core.envelope import serialize_envelope
 from senaite.astm.core.lims import post_to_senaite
 from senaite.astm.utils import parse_capture
+from senaite.astm.utils import rebuild_checksums
 from senaite.astm.wrapper import Wrapper
 
 
-def _file_to_message(fh, message_format):
+def _file_to_message(fh, message_format, rebuild=False):
     """Read a captured ASTM file and produce one message for
     `post_to_senaite`.
 
@@ -39,8 +40,16 @@ def _file_to_message(fh, message_format):
     fixture to a listener). :func:`senaite.astm.utils.parse_capture`
     extracts the individual frames; `Wrapper` turns them into the
     typed envelope.
+
+    `rebuild=True` runs :func:`rebuild_checksums` over the input
+    bytes first so a hand-edited capture (sample-id swap, PHI
+    scrub) decodes without the codec asserting on the stale 2-byte
+    trailer. Off by default so real wire captures aren't silently
+    masked when the bytes were genuinely corrupt.
     """
     raw = fh.read()
+    if rebuild:
+        raw = rebuild_checksums(raw)
     if message_format == "astm":
         return raw
 
@@ -61,6 +70,16 @@ def main():
         "-i", "--infile",
         type=argparse.FileType("rb"), nargs="+",
         help="ASTM file(s) to send to SENAITE")
+
+    astm_group.add_argument(
+        "--rebuild-checksums", action="store_true",
+        help="Recompute the 2-byte trailer of every ASTM frame "
+             "before parsing. Use this when replaying a capture "
+             "that has been hand-edited (sample-id swap, PHI "
+             "scrub, etc.) — the edit invalidates the original "
+             "checksum and the codec asserts at parse time. Off "
+             "by default so genuine wire corruption is not "
+             "silently masked.")
 
     lims_group.add_argument(
         "-u", "--url", type=str,
@@ -107,7 +126,9 @@ def main():
     messages = []
     for fh in args.infile:
         try:
-            messages.append(_file_to_message(fh, args.message_format))
+            messages.append(_file_to_message(
+                fh, args.message_format,
+                rebuild=args.rebuild_checksums))
         except Exception as exc:
             logger.error(
                 "Failed to prepare %s as %s: %s",

--- a/src/senaite/astm/tests/test_rebuild_checksums.py
+++ b/src/senaite/astm/tests/test_rebuild_checksums.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Tests for :func:`senaite.astm.utils.rebuild_checksums`.
+
+Captured ASTM files often need light edits to be useful as test
+fixtures (sample-id swap, PHI scrubbing). Each edit invalidates
+the trailing 2-byte checksum of the affected frame, and the codec
+asserts at parse time. `rebuild_checksums` recomputes every
+frame's trailer in place so the edited bytes round-trip cleanly.
+"""
+
+import io
+import os
+import unittest
+
+from senaite.astm.constants import STX
+from senaite.astm.sender import _file_to_message
+from senaite.astm.utils import make_checksum
+from senaite.astm.utils import parse_capture
+from senaite.astm.utils import rebuild_checksums
+from senaite.astm.utils import validate_checksum
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+
+
+def _captured(filename):
+    with open(os.path.join(DATA_DIR, filename), "rb") as fh:
+        return fh.read()
+
+
+class RebuildChecksumsTest(unittest.TestCase):
+
+    def test_corrupt_checksum_is_corrected(self):
+        raw = _captured("yumizen_h500.txt")
+        # corrupt the first frame's checksum to a known-bad value
+        first_frame = parse_capture(raw)[0]
+        cs_offset = raw.find(first_frame) + len(first_frame) - 2
+        broken = bytearray(raw)
+        broken[cs_offset:cs_offset + 2] = b"00"
+
+        fixed = rebuild_checksums(bytes(broken))
+        for frame in parse_capture(fixed):
+            # validate_checksum wants the full frame plus trailing
+            # CRLF; the codec accepts either.
+            self.assertTrue(validate_checksum(frame + b"\r\n"))
+
+    def test_unedited_capture_round_trips_unchanged(self):
+        raw = _captured("yumizen_h500.txt")
+        self.assertEqual(rebuild_checksums(raw), raw)
+
+    def test_non_frame_bytes_pass_through(self):
+        # ENQ / EOT / junk surrounding a single valid frame
+        body = b"5O|1|SAMPLE\rL|1|N"
+        frame = STX + body + b"\x03" + make_checksum(body + b"\x03")
+        stream = b"\x05" + frame + b"\r\n" + b"\x04"
+        self.assertEqual(rebuild_checksums(stream), stream)
+
+    def test_truncated_tail_passes_through(self):
+        # STX without a terminator — helper must not lose bytes
+        garbage = b"\x021H|\\^&|"
+        self.assertEqual(rebuild_checksums(garbage), garbage)
+
+    def test_empty_input(self):
+        self.assertEqual(rebuild_checksums(b""), b"")
+
+
+class SenderRebuildFlagTest(unittest.TestCase):
+    """`_file_to_message(..., rebuild=True)` repairs hand-edited
+    captures before the codec sees them. Off by default so real
+    captures aren't silently masked."""
+
+    def _edited_capture(self):
+        raw = _captured("yumizen_h500.txt")
+        # swap a record-body byte — invalidates that frame's
+        # checksum (the trailer was computed over the original).
+        # Replace the first lowercase 'P' of the patient record
+        # type with itself plus a marker so any frame is altered.
+        # Easier: substitute a digit inside a record body.
+        edited = raw.replace(b"|R|", b"|F|", 1)
+        self.assertNotEqual(edited, raw)
+        return edited
+
+    def test_rebuild_true_repairs_edited_capture(self):
+        edited = self._edited_capture()
+        msg = _file_to_message(
+            io.BytesIO(edited), "astm", rebuild=True)
+        # every frame now validates
+        for frame in parse_capture(msg):
+            self.assertTrue(validate_checksum(frame + b"\r\n"))
+
+    def test_rebuild_false_is_default(self):
+        raw = _captured("yumizen_h500.txt")
+        # default path must not modify the bytes
+        msg = _file_to_message(io.BytesIO(raw), "astm")
+        self.assertEqual(msg, raw)
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(RebuildChecksumsTest))
+    suite.addTest(unittest.makeSuite(SenderRebuildFlagTest))
+    return suite

--- a/src/senaite/astm/utils.py
+++ b/src/senaite/astm/utils.py
@@ -92,6 +92,56 @@ def parse_capture(raw):
     return frames
 
 
+def rebuild_checksums(raw):
+    """Return a copy of `raw` with every ASTM frame's 2-byte
+    checksum recomputed against the (possibly edited) frame body.
+
+    Captured files often need light edits to be useful in tests —
+    sample-id swaps to retarget an existing sample, PHI scrubbing,
+    bin-value tweaks for renderer smoke tests. Each edit
+    invalidates the trailing 2-byte ASTM checksum of the affected
+    frame, and the codec's `decode()` then asserts at parse time
+    (`Checksum wrong: expected ..., got ...`).
+
+    This helper walks the byte stream the same way
+    :func:`parse_capture` does — STX -> ETX or ETB -> rewrite the
+    next 2 bytes with the fresh checksum. Non-frame bytes (ENQ,
+    EOT, CRLF separators, leading/trailing junk) pass through
+    untouched.
+
+    :param raw: full file bytes
+    :returns: bytes, same length as input (checksums are 2-byte
+        hex strings, so no size change)
+    """
+    out = bytearray()
+    pos = 0
+    while True:
+        stx = raw.find(STX, pos)
+        if stx < 0:
+            out.extend(raw[pos:])
+            break
+        # bytes between the previous frame and this STX (ENQ, EOT,
+        # separators) carry through unchanged
+        out.extend(raw[pos:stx])
+        etx = raw.find(ETX, stx)
+        etb = raw.find(ETB, stx)
+        ends = [e for e in (etx, etb) if e >= 0]
+        if not ends:
+            # truncated frame at the tail — pass through as-is
+            out.extend(raw[stx:])
+            break
+        terminator = min(ends)
+        # body is STX + seq + record + terminator (no leading STX
+        # in the hashed slice; matches the codec's checksum scope)
+        body = raw[stx + 1:terminator + 1]
+        new_cs = make_checksum(body)
+        out.extend(raw[stx:terminator + 1])
+        out.extend(new_cs)
+        # skip past the old 2-byte checksum in the input
+        pos = terminator + 3
+    return bytes(out)
+
+
 def is_chunked_message(message):
     """Checks plain message for chunked byte.
     """


### PR DESCRIPTION
## Description

Captured ASTM files often need light edits to be useful as test fixtures or local replays — sample-id swap to retarget an existing sample, PHI scrubbing, bin-value tweaks for renderer smoke tests. Each edit invalidates the trailing 2-byte ASTM checksum of the affected frame, and the codec's `decode()` then asserts at parse time (`Checksum wrong: expected ..., got ...`).

Add `rebuild_checksums(raw)` to `senaite.astm.utils`. It walks the byte stream the same way `parse_capture` does (STX -> ETX/ETB -> rewrite the next 2 bytes with the fresh checksum). Non-frame bytes (ENQ, EOT, CRLF separators, junk) pass through untouched.

Wire it into `senaite-astm-send` behind `--rebuild-checksums`. Off by default so genuine wire corruption is not silently masked.

## Usage

\`\`\`
senaite-astm-send -i edited_capture.astm -m json -u http://admin:admin@localhost:8080/senaite --rebuild-checksums
\`\`\`

## Tests

- `rebuild_checksums` repairs a deliberately corrupted frame; every frame validates afterwards.
- Unedited captures round-trip unchanged.
- Non-frame bytes (ENQ/EOT/junk) pass through verbatim.
- Truncated tails and empty inputs do not raise.
- The sender flag defaults to off (no rewrite) and repairs an edited capture when on.