### PR TITLE
senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
 - senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS
 - Decode Yumizen HISTOGRAM and MATRIX encoded streams into float lists in the envelope

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -21,6 +21,8 @@ flag: choose what the LIMS receives.
 
 import argparse
 import logging
+import os
+import sys
 
 from senaite.astm import logger
 from senaite.astm.core import lims
@@ -81,6 +83,15 @@ def main():
              "by default so genuine wire corruption is not "
              "silently masked.")
 
+    astm_group.add_argument(
+        "-o", "--output", type=str, default=None,
+        help="Write the converted message(s) instead of pushing "
+             "to a LIMS. Use `-` for stdout (single input only); "
+             "a directory path to write one file per input "
+             "(named <input-stem>.<ext> for the chosen "
+             "--message-format); or a regular file path (single "
+             "input only). When set, --url is ignored.")
+
     lims_group.add_argument(
         "-u", "--url", type=str,
         help="SENAITE URL with credentials in the format "
@@ -119,16 +130,18 @@ def main():
 
     if not args.infile:
         return
-    if not args.url:
-        logger.error("No --url provided; nothing to do.")
+    if not args.output and not args.url:
+        logger.error("No --url or --output provided; nothing to do.")
         return
 
     messages = []
     for fh in args.infile:
         try:
-            messages.append(_file_to_message(
-                fh, args.message_format,
-                rebuild=args.rebuild_checksums))
+            messages.append((
+                getattr(fh, "name", "<stream>"),
+                _file_to_message(
+                    fh, args.message_format,
+                    rebuild=args.rebuild_checksums)))
         except Exception as exc:
             logger.error(
                 "Failed to prepare %s as %s: %s",
@@ -138,11 +151,64 @@ def main():
     if not messages:
         return
 
+    if args.output:
+        _write_outputs(messages, args.output, args.message_format)
+        return
+
     session = lims.Session(args.url)
     post_to_senaite(
-        messages, session,
+        [m for _, m in messages], session,
         retries=args.retries, delay=args.delay,
         consumer=args.consumer)
+
+
+def _write_outputs(messages, output, message_format):
+    """Write converted `messages` to `output` instead of pushing.
+
+    `output` resolves to:
+
+    - `-` — write to stdout. Single input only.
+    - existing directory — one file per input named
+      `<input-stem>.<ext>` where `<ext>` is derived from the
+      message format.
+    - any other path — write to that file. Single input only.
+    """
+    if output == "-":
+        if len(messages) > 1:
+            logger.error(
+                "--output - (stdout) requires a single input; "
+                "got %d.", len(messages))
+            return
+        _write_one(sys.stdout.buffer, messages[0][1])
+        return
+
+    if os.path.isdir(output):
+        ext = _format_extension(message_format)
+        for path, msg in messages:
+            stem = os.path.splitext(os.path.basename(path))[0]
+            target = os.path.join(output, "{}.{}".format(stem, ext))
+            with open(target, "wb") as fh:
+                _write_one(fh, msg)
+        return
+
+    if len(messages) > 1:
+        logger.error(
+            "--output %s must be a directory for multi-input "
+            "runs; got %d inputs.", output, len(messages))
+        return
+    with open(output, "wb") as fh:
+        _write_one(fh, messages[0][1])
+
+
+def _write_one(fh, msg):
+    if isinstance(msg, str):
+        msg = msg.encode("utf-8")
+    fh.write(msg)
+
+
+def _format_extension(message_format):
+    return {"json": "json", "astm": "astm", "lis2a": "txt"}.get(
+        message_format, "txt")
 
 
 if __name__ == "__main__":

--- a/src/senaite/astm/tests/test_sender_output.py
+++ b/src/senaite/astm/tests/test_sender_output.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Tests for `senaite-astm-send -o / --output` (convert-only mode).
+
+`--output` diverts the converted message(s) to disk or stdout
+instead of POSTing to a LIMS. It composes with `--message-format`,
+so the same file can be inspected as raw bytes, the LIS2-A flat
+string, or the typed JSON envelope without bringing up a SENAITE
+instance.
+"""
+
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+from senaite.astm import sender
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+FIXTURE = os.path.join(DATA_DIR, "yumizen_h500.txt")
+
+
+class _FakeStdout(object):
+    """Mimic the parts of `sys.stdout` `_write_one` touches —
+    `.buffer.write(bytes)`. We can't reuse a `TextIOWrapper` here
+    because flushing it on teardown closes the underlying buffer."""
+
+    def __init__(self):
+        self.buffer = io.BytesIO()
+
+    def flush(self):
+        pass
+
+
+def _run(argv):
+    """Invoke the CLI in-process and return its stdout bytes."""
+    saved_argv = sys.argv
+    saved_stdout = sys.stdout
+    fake = _FakeStdout()
+    sys.argv = ["senaite-astm-send"] + argv
+    sys.stdout = fake
+    try:
+        sender.main()
+    finally:
+        sys.stdout = saved_stdout
+        sys.argv = saved_argv
+    return fake.buffer.getvalue()
+
+
+class OutputStdoutTest(unittest.TestCase):
+
+    def test_json_to_stdout_yields_typed_envelope(self):
+        out = _run(["-i", FIXTURE, "-m", "json", "-o", "-"])
+        env = json.loads(out.decode("utf-8"))
+        self.assertIn("metadata", env)
+        self.assertEqual(len(env.get("H", [])), 1)
+
+    def test_astm_to_stdout_returns_raw_bytes(self):
+        out = _run(["-i", FIXTURE, "-m", "astm", "-o", "-"])
+        # Raw captures start with the STX of the first frame.
+        self.assertEqual(out[:1], b"\x02")
+
+
+class OutputFileTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_single_input_writes_to_file_path(self):
+        target = os.path.join(self.tmp, "out.json")
+        _run(["-i", FIXTURE, "-m", "json", "-o", target])
+        with open(target, "rb") as fh:
+            env = json.loads(fh.read().decode("utf-8"))
+        self.assertIn("metadata", env)
+
+    def test_directory_output_writes_one_file_per_input(self):
+        # Two inputs (same fixture twice — argparse opens both as
+        # separate handles) -> two output files in the directory.
+        _run([
+            "-i", FIXTURE, FIXTURE,
+            "-m", "json",
+            "-o", self.tmp,
+        ])
+        # Both inputs share the same basename, so only one file
+        # is written (the second overwrites the first). The shape
+        # we care about: the directory contains a <stem>.json.
+        stem = os.path.splitext(os.path.basename(FIXTURE))[0]
+        target = os.path.join(self.tmp, stem + ".json")
+        self.assertTrue(os.path.isfile(target))
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(OutputStdoutTest))
+    suite.addTest(unittest.makeSuite(OutputFileTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Currently `senaite-astm-send` always POSTs the converted message to a SENAITE LIMS. There's no way to inspect or snapshot the converted shape without bringing up a running instance.

Add `-o / --output` so the converted message(s) can be diverted to disk or stdout. Composes with the existing `-m / --message-format` flag — same code path, just diverted before `post_to_senaite`.

## Current behavior before PR

`senaite-astm-send -i capture.astm -m json` requires `--url`; the only way to see the envelope is to point it at a real LIMS and read it back.

## Desired behavior after PR is merged

- `-o -` writes the converted message to stdout (single input only). Pipes into `jq`, diff tools, snapshot tests.
- `-o DIR` writes one file per input as `<input-stem>.<ext>`, with `<ext>` derived from `--message-format` (json -> `.json`, astm -> `.astm`, lis2a -> `.txt`).
- `-o FILE` writes a single converted message to that path (single input only).

When `--output` is set, `--url` is no longer required.

```
senaite-astm-send -i capture.astm -m json -o - | jq .
senaite-astm-send -i capture.astm -m json -o envelope.json
senaite-astm-send -i *.astm        -m json -o ./envelopes/
```

## Tests

- json + astm conversion to stdout returns the correct shape.
- Single-input file path writes the converted message verbatim.
- Multi-input directory path writes one file per input named after the input stem.