### PR TITLE
senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file
 - senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
 - senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -33,7 +33,8 @@ from senaite.astm.utils import rebuild_checksums
 from senaite.astm.wrapper import Wrapper
 
 
-def _file_to_message(fh, message_format, rebuild=False):
+def _file_to_message(fh, message_format, rebuild=False,
+                     substitutions=None):
     """Read a captured ASTM file and produce one message for
     `post_to_senaite`.
 
@@ -48,8 +49,18 @@ def _file_to_message(fh, message_format, rebuild=False):
     scrub) decodes without the codec asserting on the stale 2-byte
     trailer. Off by default so real wire captures aren't silently
     masked when the bytes were genuinely corrupt.
+
+    `substitutions` is an optional list of `(old, new)` byte pairs
+    applied to the raw bytes before any other processing. Used
+    primarily to retarget the sample id of a captured message
+    (`CLVB262200 -> CLVB262205`) so the same fixture can be
+    replayed against successive registrations. Any substitution
+    that changes a frame body invalidates the trailing checksum,
+    so the typical companion flag is `--rebuild-checksums`.
     """
     raw = fh.read()
+    if substitutions:
+        raw = _apply_substitutions(raw, substitutions)
     if rebuild:
         raw = rebuild_checksums(raw)
     if message_format == "astm":
@@ -58,6 +69,37 @@ def _file_to_message(fh, message_format, rebuild=False):
     frames = parse_capture(raw)
     envelope = Wrapper(frames).to_envelope()
     return serialize_envelope(envelope, message_format)
+
+
+def _apply_substitutions(raw, substitutions):
+    """Apply each `(old, new)` byte pair to `raw` in order.
+
+    Plain `bytes.replace` — global, literal, no regex. Order
+    matters only when the user supplies pairs that overlap each
+    other, in which case the explicit ordering is the only sane
+    contract.
+    """
+    for old, new in substitutions:
+        raw = raw.replace(old, new)
+    return raw
+
+
+def _parse_substitution(value):
+    """Argparse type converter for `--substitute-sample-id`.
+
+    Accepts `OLD=NEW`; rejects forms with no `=` or an empty side.
+    Returns the pair as bytes (latin-1; ASTM payloads are 8-bit
+    clean), so the substitution can be applied directly to the
+    raw capture stream without an intermediate decode.
+    """
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            "expected OLD=NEW, got %r" % value)
+    old, new = value.split("=", 1)
+    if not old:
+        raise argparse.ArgumentTypeError(
+            "OLD side of substitution is empty: %r" % value)
+    return (old.encode("latin-1"), new.encode("latin-1"))
 
 
 def main():
@@ -72,6 +114,18 @@ def main():
         "-i", "--infile",
         type=argparse.FileType("rb"), nargs="+",
         help="ASTM file(s) to send to SENAITE")
+
+    astm_group.add_argument(
+        "--substitute-sample-id", dest="substitutions",
+        action="append", default=[], metavar="OLD=NEW",
+        type=_parse_substitution,
+        help="Replace every occurrence of OLD with NEW in the raw "
+             "capture before parsing. Repeatable. Primary use: "
+             "retarget a captured ASTM file to a different sample "
+             "id so the same fixture can be replayed against a "
+             "fresh registration without editing the file. The "
+             "substitution invalidates the affected frame's "
+             "checksum, so combine with --rebuild-checksums.")
 
     astm_group.add_argument(
         "--rebuild-checksums", action="store_true",
@@ -141,7 +195,8 @@ def main():
                 getattr(fh, "name", "<stream>"),
                 _file_to_message(
                     fh, args.message_format,
-                    rebuild=args.rebuild_checksums)))
+                    rebuild=args.rebuild_checksums,
+                    substitutions=args.substitutions)))
         except Exception as exc:
             logger.error(
                 "Failed to prepare %s as %s: %s",

--- a/src/senaite/astm/tests/test_sender_substitute.py
+++ b/src/senaite/astm/tests/test_sender_substitute.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Tests for `senaite-astm-send --substitute-sample-id OLD=NEW`.
+
+The flag retargets a captured ASTM file to a different sample id
+so the same fixture can be replayed against a fresh registration
+without editing the file. Combines with `--rebuild-checksums` so
+the trailer-invalidating edit round-trips through the codec.
+"""
+
+import argparse
+import io
+import os
+import unittest
+
+from senaite.astm.sender import _apply_substitutions
+from senaite.astm.sender import _file_to_message
+from senaite.astm.sender import _parse_substitution
+from senaite.astm.utils import parse_capture
+from senaite.astm.utils import validate_checksum
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+FIXTURE = "yumizen_h500.txt"
+
+
+def _captured(filename):
+    with open(os.path.join(DATA_DIR, filename), "rb") as fh:
+        return fh.read()
+
+
+class ParseSubstitutionTest(unittest.TestCase):
+
+    def test_valid_pair_returns_bytes_tuple(self):
+        old, new = _parse_substitution("AAA=BBB")
+        self.assertEqual(old, b"AAA")
+        self.assertEqual(new, b"BBB")
+
+    def test_empty_new_is_allowed(self):
+        # OLD=  is a delete; useful for scrubbing
+        old, new = _parse_substitution("XYZ=")
+        self.assertEqual((old, new), (b"XYZ", b""))
+
+    def test_missing_equals_rejected(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            _parse_substitution("no-equals-sign")
+
+    def test_empty_old_rejected(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            _parse_substitution("=NEW")
+
+
+class ApplySubstitutionsTest(unittest.TestCase):
+
+    def test_single_replacement(self):
+        result = _apply_substitutions(
+            b"hello world", [(b"world", b"there")])
+        self.assertEqual(result, b"hello there")
+
+    def test_replacements_are_global(self):
+        result = _apply_substitutions(
+            b"a b a b a", [(b"a", b"X")])
+        self.assertEqual(result, b"X b X b X")
+
+    def test_pairs_apply_in_order(self):
+        # Order matters when later pairs see earlier substitutions
+        result = _apply_substitutions(
+            b"AAA", [(b"AAA", b"BBB"), (b"BBB", b"CCC")])
+        self.assertEqual(result, b"CCC")
+
+    def test_no_pairs_returns_input_verbatim(self):
+        raw = b"\x021H|\\^&|"
+        self.assertEqual(_apply_substitutions(raw, []), raw)
+
+
+class SenderSubstituteFlagTest(unittest.TestCase):
+    """End-to-end: substitution + checksum rebuild yields a
+    capture whose Order record carries the new sample id and
+    whose frames all validate."""
+
+    def test_sample_id_swap_with_rebuild(self):
+        raw = _captured(FIXTURE)
+        # Locate the original sample id in the Order frame.
+        # The Yumizen fixture's order record carries `PX440N`.
+        self.assertIn(b"PX440N", raw)
+
+        msg = _file_to_message(
+            io.BytesIO(raw),
+            "astm",
+            rebuild=True,
+            substitutions=[(b"PX440N", b"CLVB262299")])
+        self.assertIn(b"CLVB262299", msg)
+        self.assertNotIn(b"PX440N", msg)
+        for frame in parse_capture(msg):
+            self.assertTrue(validate_checksum(frame + b"\r\n"))
+
+    def test_substitution_without_rebuild_breaks_checksum(self):
+        # Documents the contract: the user must combine with
+        # --rebuild-checksums or the codec asserts later.
+        raw = _captured(FIXTURE)
+        msg = _file_to_message(
+            io.BytesIO(raw),
+            "astm",
+            rebuild=False,
+            substitutions=[(b"PX440N", b"CLVB262299")])
+        # At least one frame should now fail validation since the
+        # body changed but the trailer didn't.
+        bad = [f for f in parse_capture(msg)
+               if not validate_checksum(f + b"\r\n")]
+        self.assertGreater(len(bad), 0)
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(ParseSubstitutionTest))
+    suite.addTests(loader.loadTestsFromTestCase(ApplySubstitutionsTest))
+    suite.addTests(loader.loadTestsFromTestCase(SenderSubstituteFlagTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Captured ASTM files are typically replayed against successive sample registrations during development — same fixture, fresh sample id each time. Doing this by editing the binary capture (hex editor or scripted byte-swap) is fragile and easy to get wrong.

## Current behavior before PR

Workflow involves opening the capture in a hex editor, locating the sample id bytes, substituting them, and running a separate script to rebuild checksums before `senaite-astm-send` can replay it.

## Desired behavior after PR is merged

Add `--substitute-sample-id OLD=NEW` (repeatable) so the substitution happens inside the sender, against the in-memory raw bytes, before any other processing. The flag is literal `bytes.replace` applied to the capture — kept general on purpose so it also handles light scrub work (instrument serial, date, tag values) when needed.

Since any substitution that changes a frame body invalidates the trailing ASTM checksum, the typical companion flag is `--rebuild-checksums`.

```
senaite-astm-send -i capture.astm \
    --substitute-sample-id CLVB262200=CLVB262299 \
    --rebuild-checksums \
    -u http://admin:admin@localhost:8080/senaite
```

## Tests

- Argparse converter accepts `OLD=NEW` and rejects malformed forms.
- `_apply_substitutions` is global, ordered, and a no-op for empty pair lists.
- End-to-end: substituting + rebuilding yields a capture whose Order record carries the new id and whose frames all validate.
- Substituting without rebuild breaks at least one checksum (contract assertion).