### PR TITLE
senaite-astm-send: add --scrub-phi to redact patient identifiers in the JSON envelope before pushing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file
 - senaite-astm-server: add --admin-port for a read-only HTTP /stats endpoint (uptime, sessions, dispatches)
 - senaite-astm-send: add --validate-only to parse + envelope-check captures without pushing to a LIMS
+- senaite-astm-send: add --scrub-phi to redact patient identifiers in the JSON envelope before pushing
 - senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
 - senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -32,9 +32,28 @@ from senaite.astm.utils import parse_capture
 from senaite.astm.utils import rebuild_checksums
 from senaite.astm.wrapper import Wrapper
 
+# Conservative default set of P-record keys that almost always
+# carry identifying / medical information. The full P record has
+# 30+ fields (see senaite.astm.records.PatientRecord); this set
+# targets the obvious ones. Use --scrub-phi-extra-fields to add
+# vendor-specific keys not covered here.
+PHI_KEYS = (
+    "name",
+    "maiden_name",
+    "birthdate",
+    "address",
+    "phone",
+    "id",
+    "physician_id",
+    "diagnosis",
+    "medication",
+)
+PHI_REDACTION = "<REDACTED>"
+
 
 def _file_to_message(fh, message_format, rebuild=False,
-                     substitutions=None):
+                     substitutions=None,
+                     scrub_phi=False, phi_extra=()):
     """Read a captured ASTM file and produce one message for
     `post_to_senaite`.
 
@@ -57,6 +76,14 @@ def _file_to_message(fh, message_format, rebuild=False,
     replayed against successive registrations. Any substitution
     that changes a frame body invalidates the trailing checksum,
     so the typical companion flag is `--rebuild-checksums`.
+
+    `scrub_phi=True` replaces the values of well-known
+    patient-identifying keys in every P record with `<REDACTED>`
+    before the envelope is serialised. Only the parsed-JSON path
+    can be scrubbed safely; raw ASTM bytes and the flat LIS2-A
+    text in `metadata.*` are not rewritten, so the caller should
+    use `-m json`. `phi_extra` adds vendor-specific keys to the
+    default set (see :data:`PHI_KEYS`).
     """
     raw = fh.read()
     if substitutions:
@@ -68,6 +95,8 @@ def _file_to_message(fh, message_format, rebuild=False,
 
     frames = parse_capture(raw)
     envelope = Wrapper(frames).to_envelope()
+    if scrub_phi:
+        _scrub_envelope_phi(envelope, phi_extra)
     return serialize_envelope(envelope, message_format)
 
 
@@ -100,6 +129,26 @@ def _parse_substitution(value):
         raise argparse.ArgumentTypeError(
             "OLD side of substitution is empty: %r" % value)
     return (old.encode("latin-1"), new.encode("latin-1"))
+
+
+def _scrub_envelope_phi(envelope, extra_keys=()):
+    """Replace the values of PHI keys in every P record of
+    `envelope` with :data:`PHI_REDACTION`, in place.
+
+    Also drops the verbatim flat-text payloads in `metadata.astm`
+    and `metadata.lis2a` so a JSON-scrubbed message can't be
+    pulled back to its un-scrubbed raw form by a downstream
+    consumer that only looks at metadata.
+    """
+    keys = set(PHI_KEYS) | set(extra_keys)
+    for patient in envelope.P:
+        for key in list(patient.keys()):
+            if key in keys and patient[key]:
+                patient[key] = PHI_REDACTION
+    if envelope.metadata.astm:
+        envelope.metadata.astm = ""
+    if envelope.metadata.lis2a:
+        envelope.metadata.lis2a = ""
 
 
 def main():
@@ -136,6 +185,23 @@ def main():
              "failed to parse. Useful as a CI check that a captured "
              "fixture still rounds through the codec + envelope "
              "schema after changes to either.")
+
+    astm_group.add_argument(
+        "--scrub-phi", action="store_true",
+        help="Redact patient-identifying fields in every P record "
+             "(name, birthdate, address, phone, IDs, diagnosis, "
+             "medication) with '<REDACTED>' before serialising. "
+             "Also clears the verbatim metadata.astm / "
+             "metadata.lis2a payloads so the un-scrubbed bytes "
+             "do not leak through. Requires --message-format json; "
+             "the raw / flat formats cannot be rewritten safely.")
+
+    astm_group.add_argument(
+        "--scrub-phi-extra-field", dest="phi_extra",
+        action="append", default=[], metavar="KEY",
+        help="Additional P-record key to redact under --scrub-phi. "
+             "Repeatable; vendor-specific keys not covered by the "
+             "default set go here.")
 
     astm_group.add_argument(
         "--rebuild-checksums", action="store_true",
@@ -198,6 +264,12 @@ def main():
     if args.validate_only:
         sys.exit(_validate_only(args.infile, args.rebuild_checksums))
 
+    if args.scrub_phi and args.message_format != "json":
+        logger.error(
+            "--scrub-phi requires --message-format json; "
+            "raw ASTM bytes and the flat LIS2-A text cannot be "
+            "rewritten safely.")
+        return
     if not args.output and not args.url:
         logger.error("No --url or --output provided; nothing to do.")
         return
@@ -210,7 +282,9 @@ def main():
                 _file_to_message(
                     fh, args.message_format,
                     rebuild=args.rebuild_checksums,
-                    substitutions=args.substitutions)))
+                    substitutions=args.substitutions,
+                    scrub_phi=args.scrub_phi,
+                    phi_extra=args.phi_extra)))
         except Exception as exc:
             logger.error(
                 "Failed to prepare %s as %s: %s",

--- a/src/senaite/astm/tests/test_sender_scrub_phi.py
+++ b/src/senaite/astm/tests/test_sender_scrub_phi.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Tests for `senaite-astm-send --scrub-phi`.
+
+The flag redacts patient-identifying fields in the typed envelope
+before serialisation so real captures can be replayed against a
+dev / staging LIMS without leaking PHI. Only the JSON output is
+scrubbed; raw ASTM / LIS2-A bytes are intentionally cleared so a
+downstream consumer can't pull them back to the unredacted form.
+"""
+
+import json
+import os
+import unittest
+
+from senaite.astm.core.envelope import Envelope
+from senaite.astm.core.envelope import Metadata
+from senaite.astm.sender import PHI_KEYS
+from senaite.astm.sender import PHI_REDACTION
+from senaite.astm.sender import _file_to_message
+from senaite.astm.sender import _scrub_envelope_phi
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+FIXTURE = os.path.join(DATA_DIR, "yumizen_h500.txt")
+
+
+def _envelope(scrub=False, phi_extra=()):
+    msg = _file_to_message(
+        open(FIXTURE, "rb"), "json",
+        scrub_phi=scrub, phi_extra=phi_extra)
+    return json.loads(msg)
+
+
+class ScrubPhiTest(unittest.TestCase):
+
+    def test_default_phi_keys_are_redacted(self):
+        env = _envelope(scrub=True)
+        for patient in env["P"]:
+            for key in PHI_KEYS:
+                if key in patient and patient[key]:
+                    self.assertEqual(
+                        patient[key], PHI_REDACTION,
+                        "%s leaked: %r" % (key, patient[key]))
+
+    def test_non_phi_fields_pass_through_unchanged(self):
+        original = _envelope(scrub=False)
+        scrubbed = _envelope(scrub=True)
+        # Sex is not in PHI_KEYS — must not be redacted.
+        for orig, scrub in zip(original["P"], scrubbed["P"]):
+            if "sex" in orig:
+                self.assertEqual(scrub.get("sex"), orig.get("sex"))
+
+    def test_metadata_raw_payloads_are_cleared(self):
+        env = _envelope(scrub=True)
+        # Both flat-text payloads carry the verbatim records and
+        # would re-leak the patient name; the scrubber clears them.
+        self.assertEqual(env["metadata"].get("astm", ""), "")
+        self.assertEqual(env["metadata"].get("lis2a", ""), "")
+
+    def test_metadata_payloads_present_without_scrub(self):
+        env = _envelope(scrub=False)
+        # Sanity: at least one of the flat payloads is populated
+        # in the unscrubbed envelope.
+        self.assertTrue(
+            env["metadata"].get("astm")
+            or env["metadata"].get("lis2a"))
+
+    def test_extra_field_is_redacted(self):
+        # The bundled fixture's P record only has type/seq
+        # populated, so verify --scrub-phi-extra-field at the
+        # function level with a synthetic envelope.
+        env = Envelope(metadata=Metadata())
+        env.P.append({
+            "type": "P",
+            "seq": "1",
+            "name": "Doe^John",
+            "vendor_tag": "lab-internal-id-42",
+        })
+        _scrub_envelope_phi(env, extra_keys=("vendor_tag",))
+        self.assertEqual(env.P[0]["name"], PHI_REDACTION)
+        self.assertEqual(env.P[0]["vendor_tag"], PHI_REDACTION)
+        # type / seq are not in the keys set
+        self.assertEqual(env.P[0]["type"], "P")
+        self.assertEqual(env.P[0]["seq"], "1")
+
+
+class ScrubPhiNoOpTest(unittest.TestCase):
+
+    def test_scrub_off_leaves_envelope_unchanged(self):
+        msg_plain = _file_to_message(
+            open(FIXTURE, "rb"), "json")
+        msg_explicit_off = _file_to_message(
+            open(FIXTURE, "rb"), "json", scrub_phi=False)
+        self.assertEqual(msg_plain, msg_explicit_off)
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(ScrubPhiTest))
+    suite.addTests(loader.loadTestsFromTestCase(ScrubPhiNoOpTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Replaying real captured ASTM files into a dev / staging LIMS is the fastest way to exercise the import path end-to-end. But real captures carry PHI — patient name, DOB, address — that has no business landing in non-production databases.

Add `--scrub-phi` so the sender redacts well-known patient-identifying fields in the typed envelope before serialisation.

## Current behavior before PR

The only way to replay a real capture safely is to hand-edit the bytes (or write a one-off Python script) to strip PHI before invoking `senaite-astm-send`. Easy to miss a field.

## Desired behavior after PR is merged

```
senaite-astm-send -i real_capture.astm --scrub-phi -m json \
    -u http://admin:admin@staging.lab.invalid/senaite
```

- Redacts every value of well-known P-record PHI keys (`name`, `maiden_name`, `birthdate`, `address`, `phone`, `id`, `physician_id`, `diagnosis`, `medication`) with `<REDACTED>`.
- Clears `metadata.astm` and `metadata.lis2a` so the un-scrubbed flat-text payloads cannot leak through.
- `--scrub-phi-extra-field KEY` (repeatable) adds vendor-specific keys.
- Requires `--message-format json` (the only output we can rewrite safely; raw ASTM / flat LIS2-A frame layouts are vendor-specific).

## Tests

- Every default key in every P record is `<REDACTED>` after scrub.
- Non-PHI fields pass through unchanged.
- `metadata.astm` / `metadata.lis2a` are cleared on scrub, present otherwise.
- `--scrub-phi-extra-field` redacts additional vendor-specific keys.
- Default (no `--scrub-phi`) is a no-op.