### PR TITLE
senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file
 - senaite-astm-server: add --admin-port for a read-only HTTP /stats endpoint (uptime, sessions, dispatches)
 - senaite-astm-send: add --validate-only to parse + envelope-check captures without pushing to a LIMS

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -50,10 +50,17 @@ PHI_KEYS = (
 )
 PHI_REDACTION = "<REDACTED>"
 
+# Record buckets the envelope splits frames into. Used to validate
+# --filter-records / --drop-records arguments at parse time so a
+# typo (e.g. "X") fails immediately instead of silently doing
+# nothing.
+RECORD_TYPES = ("H", "P", "O", "R", "C", "M", "L", "Q")
+
 
 def _file_to_message(fh, message_format, rebuild=False,
                      substitutions=None,
-                     scrub_phi=False, phi_extra=()):
+                     scrub_phi=False, phi_extra=(),
+                     keep_records=None, drop_records=None):
     """Read a captured ASTM file and produce one message for
     `post_to_senaite`.
 
@@ -84,6 +91,14 @@ def _file_to_message(fh, message_format, rebuild=False,
     text in `metadata.*` are not rewritten, so the caller should
     use `-m json`. `phi_extra` adds vendor-specific keys to the
     default set (see :data:`PHI_KEYS`).
+
+    `keep_records` / `drop_records` (mutually exclusive; pass at
+    most one) trim the parsed envelope's per-type buckets before
+    serialisation. Useful for producing a stripped fixture that
+    exercises one specific consumer path. Only the JSON output
+    reflects the trimming — raw ASTM bytes and the flat LIS2-A
+    text are vendor-specific and cannot be re-emitted from a
+    pruned envelope.
     """
     raw = fh.read()
     if substitutions:
@@ -97,6 +112,8 @@ def _file_to_message(fh, message_format, rebuild=False,
     envelope = Wrapper(frames).to_envelope()
     if scrub_phi:
         _scrub_envelope_phi(envelope, phi_extra)
+    if keep_records or drop_records:
+        _filter_envelope_records(envelope, keep_records, drop_records)
     return serialize_envelope(envelope, message_format)
 
 
@@ -151,6 +168,41 @@ def _scrub_envelope_phi(envelope, extra_keys=()):
         envelope.metadata.lis2a = ""
 
 
+def _filter_envelope_records(envelope, keep, drop):
+    """Trim per-type buckets on `envelope` in place.
+
+    Exactly one of `keep` / `drop` is honoured; the caller has
+    already validated they are not both set.
+    """
+    if keep:
+        for rt in RECORD_TYPES:
+            if rt not in keep:
+                getattr(envelope, rt)[:] = []
+    elif drop:
+        for rt in drop:
+            getattr(envelope, rt)[:] = []
+
+
+def _parse_record_list(value):
+    """Argparse type converter for `--filter-records` / `--drop-records`.
+
+    Accepts a comma-separated list of record-type letters. Each
+    letter is normalised to upper-case; unknown letters fail
+    parsing so a typo can't silently no-op.
+    """
+    parts = [p.strip().upper() for p in value.split(",") if p.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError(
+            "expected a comma-separated list of record types, "
+            "got %r" % value)
+    bad = [p for p in parts if p not in RECORD_TYPES]
+    if bad:
+        raise argparse.ArgumentTypeError(
+            "unknown record type(s) %s; known: %s"
+            % (",".join(bad), ",".join(RECORD_TYPES)))
+    return tuple(parts)
+
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -202,6 +254,26 @@ def main():
         help="Additional P-record key to redact under --scrub-phi. "
              "Repeatable; vendor-specific keys not covered by the "
              "default set go here.")
+
+    astm_group.add_argument(
+        "--filter-records", type=_parse_record_list, default=None,
+        metavar="TYPES",
+        help="Keep only the listed record-type buckets in the "
+             "parsed envelope; drop the rest. Example: "
+             "--filter-records H,O,R keeps headers, orders, "
+             "results. Mutually exclusive with --drop-records. "
+             "Requires --message-format json (raw and flat "
+             "outputs cannot be re-emitted from a pruned "
+             "envelope).")
+
+    astm_group.add_argument(
+        "--drop-records", type=_parse_record_list, default=None,
+        metavar="TYPES",
+        help="Drop the listed record-type buckets from the parsed "
+             "envelope; keep the rest. Example: --drop-records C,M "
+             "drops comments and manufacturer rows. Mutually "
+             "exclusive with --filter-records. Requires "
+             "--message-format json.")
 
     astm_group.add_argument(
         "--rebuild-checksums", action="store_true",
@@ -270,6 +342,18 @@ def main():
             "raw ASTM bytes and the flat LIS2-A text cannot be "
             "rewritten safely.")
         return
+    if args.filter_records and args.drop_records:
+        logger.error(
+            "--filter-records and --drop-records are mutually "
+            "exclusive; pass at most one.")
+        return
+    if (args.filter_records or args.drop_records) \
+            and args.message_format != "json":
+        logger.error(
+            "--filter-records / --drop-records require "
+            "--message-format json; raw ASTM and flat LIS2-A "
+            "cannot be re-emitted from a pruned envelope.")
+        return
     if not args.output and not args.url:
         logger.error("No --url or --output provided; nothing to do.")
         return
@@ -284,7 +368,9 @@ def main():
                     rebuild=args.rebuild_checksums,
                     substitutions=args.substitutions,
                     scrub_phi=args.scrub_phi,
-                    phi_extra=args.phi_extra)))
+                    phi_extra=args.phi_extra,
+                    keep_records=args.filter_records,
+                    drop_records=args.drop_records)))
         except Exception as exc:
             logger.error(
                 "Failed to prepare %s as %s: %s",

--- a/src/senaite/astm/tests/test_sender_filter_records.py
+++ b/src/senaite/astm/tests/test_sender_filter_records.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Tests for `senaite-astm-send --filter-records` / `--drop-records`.
+
+Both flags trim the typed envelope's per-type buckets in place
+before serialisation, producing a stripped fixture useful for
+exercising one specific consumer path.
+"""
+
+import argparse
+import json
+import os
+import unittest
+
+from senaite.astm.core.envelope import Envelope
+from senaite.astm.core.envelope import Metadata
+from senaite.astm.sender import RECORD_TYPES
+from senaite.astm.sender import _file_to_message
+from senaite.astm.sender import _filter_envelope_records
+from senaite.astm.sender import _parse_record_list
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+FIXTURE = os.path.join(DATA_DIR, "yumizen_h500.txt")
+
+
+def _envelope(**kw):
+    return json.loads(
+        _file_to_message(open(FIXTURE, "rb"), "json", **kw))
+
+
+class ParseRecordListTest(unittest.TestCase):
+
+    def test_accepts_comma_separated(self):
+        self.assertEqual(_parse_record_list("H,O,R"), ("H", "O", "R"))
+
+    def test_normalises_case_and_whitespace(self):
+        self.assertEqual(
+            _parse_record_list(" h , o , r "),
+            ("H", "O", "R"))
+
+    def test_rejects_unknown_letter(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            _parse_record_list("H,X")
+
+    def test_rejects_empty(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            _parse_record_list(",,")
+
+
+class FilterEnvelopeTest(unittest.TestCase):
+
+    def _populated_envelope(self):
+        env = Envelope(metadata=Metadata())
+        for rt in RECORD_TYPES:
+            getattr(env, rt).append({"type": rt})
+        return env
+
+    def test_keep_only_listed(self):
+        env = self._populated_envelope()
+        _filter_envelope_records(env, ("H", "O"), None)
+        self.assertEqual(env.H[0]["type"], "H")
+        self.assertEqual(env.O[0]["type"], "O")
+        for rt in ("P", "R", "C", "M", "L", "Q"):
+            self.assertEqual(getattr(env, rt), [])
+
+    def test_drop_removes_listed(self):
+        env = self._populated_envelope()
+        _filter_envelope_records(env, None, ("C", "M"))
+        self.assertEqual(env.C, [])
+        self.assertEqual(env.M, [])
+        for rt in ("H", "P", "O", "R", "L", "Q"):
+            self.assertEqual(getattr(env, rt)[0]["type"], rt)
+
+
+class FilterEndToEndTest(unittest.TestCase):
+
+    def test_filter_keeps_only_listed_buckets(self):
+        env = _envelope(keep_records=("H",))
+        self.assertEqual(len(env["H"]), 1)
+        for rt in ("P", "O", "R", "C", "M"):
+            self.assertEqual(env.get(rt, []), [])
+
+    def test_drop_clears_listed_buckets(self):
+        env_full = _envelope()
+        # M (manufacturer) is populated by the Yumizen fixture.
+        self.assertGreater(len(env_full.get("M", [])), 0)
+        env_no_m = _envelope(drop_records=("M",))
+        self.assertEqual(env_no_m["M"], [])
+        # other buckets pass through unchanged
+        self.assertEqual(len(env_no_m["H"]), len(env_full["H"]))
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(ParseRecordListTest))
+    suite.addTests(loader.loadTestsFromTestCase(FilterEnvelopeTest))
+    suite.addTests(loader.loadTestsFromTestCase(FilterEndToEndTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When developing a consumer that only cares about a subset of ASTM record types (e.g. results), it is useful to feed it stripped fixtures so unrelated record types do not muddy the test. Today the only way to do that is to hand-edit the capture.

## Current behavior before PR

Producing a trimmed fixture requires either hand-editing the byte stream or running a separate Python preprocessor.

## Desired behavior after PR is merged

```
senaite-astm-send -i capture.astm -m json -o - --filter-records H,O,R | jq .
senaite-astm-send -i capture.astm -m json --drop-records C,M -u http://...
```

- `--filter-records TYPES` keeps only the listed buckets.
- `--drop-records TYPES` removes the listed buckets.
- Mutually exclusive; pass at most one.
- Argparse validates each letter against the known set (`H,P,O,R,C,M,L,Q`) so a typo fails immediately instead of silently no-opping.
- Requires `--message-format json` (raw ASTM and flat LIS2-A cannot be re-emitted from a pruned envelope).

## Tests

- Parser accepts comma-separated, normalises case, rejects unknown letters and empty input.
- Function-level: keep-only and drop trim the right buckets.
- End-to-end on the Yumizen fixture: `--filter-records H` keeps only H; `--drop-records M` clears the populated manufacturer bucket while leaving the rest intact.