### PR TITLE
senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
 - senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -118,6 +118,14 @@ def main():
         "-d", "--delay", type=int, default=5,
         help="Seconds between push retries")
 
+    lims_group.add_argument(
+        "--dry-run", action="store_true",
+        help="Log the URL, consumer, message count and per-message "
+             "format + byte size that would be pushed to the LIMS, "
+             "then exit without opening a connection. The URL "
+             "password is masked. Useful for confirming the right "
+             "target and payload before committing.")
+
     parser.add_argument(
         "-v", "--verbose", action="store_true",
         help="Verbose logging")
@@ -155,11 +163,49 @@ def main():
         _write_outputs(messages, args.output, args.message_format)
         return
 
+    if args.dry_run:
+        _print_dry_run(
+            messages, args.url, args.consumer,
+            args.message_format)
+        return
+
     session = lims.Session(args.url)
     post_to_senaite(
         [m for _, m in messages], session,
         retries=args.retries, delay=args.delay,
         consumer=args.consumer)
+
+
+def _print_dry_run(messages, url, consumer, message_format):
+    """Log what would be sent to the LIMS without opening a
+    connection. The URL's password component is masked so the
+    output is safe to paste into a bug report."""
+    logger.info("DRY RUN — no request will be sent")
+    logger.info("  url:      %s", _mask_url_password(url))
+    logger.info("  consumer: %s", consumer)
+    logger.info("  format:   %s", message_format)
+    logger.info("  messages: %d", len(messages))
+    for path, msg in messages:
+        size = len(msg) if msg is not None else 0
+        logger.info("    - %s (%d bytes)", path, size)
+
+
+def _mask_url_password(url):
+    """Return `url` with the password component replaced by ***.
+
+    Accepts the project's standard form
+    `http(s)://user:password@host[:port]/path`. Returns the URL
+    unchanged when no credentials are embedded."""
+    if not url or "@" not in url:
+        return url or ""
+    scheme, _, rest = url.partition("://")
+    if "@" not in rest:
+        return url
+    creds, _, tail = rest.partition("@")
+    if ":" not in creds:
+        return url
+    user, _, _ = creds.partition(":")
+    return "{}://{}:***@{}".format(scheme, user, tail)
 
 
 def _write_outputs(messages, output, message_format):

--- a/src/senaite/astm/tests/test_sender_dry_run.py
+++ b/src/senaite/astm/tests/test_sender_dry_run.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""Tests for `senaite-astm-send --dry-run` and the URL password
+masking helper it relies on."""
+
+import io
+import logging
+import os
+import sys
+import unittest
+
+from senaite.astm import sender
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+FIXTURE = os.path.join(DATA_DIR, "yumizen_h500.txt")
+
+
+class MaskUrlPasswordTest(unittest.TestCase):
+
+    def test_masks_password(self):
+        self.assertEqual(
+            sender._mask_url_password(
+                "http://admin:secret@localhost:8080/senaite"),
+            "http://admin:***@localhost:8080/senaite")
+
+    def test_https_masked(self):
+        self.assertEqual(
+            sender._mask_url_password(
+                "https://u:p@host/path"),
+            "https://u:***@host/path")
+
+    def test_no_credentials_passes_through(self):
+        url = "http://localhost:8080/senaite"
+        self.assertEqual(sender._mask_url_password(url), url)
+
+    def test_username_only_passes_through(self):
+        # No `:` in the creds portion -> nothing to mask.
+        url = "http://justuser@localhost/path"
+        self.assertEqual(sender._mask_url_password(url), url)
+
+    def test_empty_or_none(self):
+        self.assertEqual(sender._mask_url_password(""), "")
+        self.assertEqual(sender._mask_url_password(None), "")
+
+
+class _CaptureHandler(logging.Handler):
+    """Capture log records into a list for assertion."""
+
+    def __init__(self):
+        super(_CaptureHandler, self).__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(self.format(record))
+
+
+class DryRunCliTest(unittest.TestCase):
+    """Run the CLI in-process with `--dry-run` and confirm the
+    password is masked, the LIMS is not contacted, and the
+    summary line lists each message size."""
+
+    def setUp(self):
+        self.handler = _CaptureHandler()
+        self.handler.setLevel(logging.INFO)
+        sender.logger.addHandler(self.handler)
+        sender.logger.setLevel(logging.INFO)
+        self._saved_argv = sys.argv
+
+    def tearDown(self):
+        sender.logger.removeHandler(self.handler)
+        sys.argv = self._saved_argv
+
+    def test_dry_run_does_not_call_post_to_senaite(self):
+        called = {"hit": False}
+
+        def fake_post(*a, **kw):
+            called["hit"] = True
+
+        original = sender.post_to_senaite
+        sender.post_to_senaite = fake_post
+        try:
+            sys.argv = [
+                "senaite-astm-send",
+                "-i", FIXTURE,
+                "-u", "http://admin:secret@localhost/senaite",
+                "--dry-run",
+            ]
+            sender.main()
+        finally:
+            sender.post_to_senaite = original
+
+        self.assertFalse(called["hit"])
+        output = "\n".join(self.handler.records)
+        self.assertIn("DRY RUN", output)
+        self.assertIn("admin:***", output)
+        self.assertNotIn("secret", output)
+        self.assertIn("messages: 1", output)
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(MaskUrlPasswordTest))
+    suite.addTests(loader.loadTestsFromTestCase(DryRunCliTest))
+    return suite

--- a/src/senaite/astm/tests/test_sender_dry_run.py
+++ b/src/senaite/astm/tests/test_sender_dry_run.py
@@ -2,7 +2,6 @@
 """Tests for `senaite-astm-send --dry-run` and the URL password
 masking helper it relies on."""
 
-import io
 import logging
 import os
 import sys


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When wiring up a replay against a new LIMS or a new consumer, it is useful to confirm the right target, consumer name, and payload size before actually committing the POST. Today the only way to confirm the URL and consumer is to send it and read the result.

## Current behavior before PR

No safe rehearsal — running the CLI hits the LIMS.

## Desired behavior after PR is merged

```
$ senaite-astm-send -i capture.astm -u http://admin:secret@localhost/senaite --dry-run
DRY RUN — no request will be sent
  url:      http://admin:***@localhost/senaite
  consumer: senaite.core.lis2a.import
  format:   json
  messages: 1
    - capture.astm (14872 bytes)
```

- Logs URL (password masked), consumer, format, message count, per-message size.
- Does not open a connection.
- Composes with `--message-format`, `--rebuild-checksums`, etc.

## Tests

- URL password masker handles http/https, no-credential and username-only forms, empty and `None`.
- CLI: `--dry-run` does not invoke `post_to_senaite`, logs `DRY RUN`, masks the password, lists the message count.