### PR TITLE
Add client (connect) mode for passive instruments / serial-to-LAN gateways

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
-- #25 Add client (connect) mode to actively connect out to passive instruments
+- #61 Add client (connect) mode to actively connect out to passive instruments
 - #23 Add Cepheid GeneXpert import schema
 - #22 Add Horiba Pentra XLR import schema
 - #21 Add Biomérieux MINI VIDAS® import schema

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #25 Add client (connect) mode to actively connect out to passive instruments
 - #23 Add Cepheid GeneXpert import schema
 - #22 Add Horiba Pentra XLR import schema
 - #21 Add Biomérieux MINI VIDAS® import schema

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -44,6 +44,10 @@ class ASTMProtocol(asyncio.Protocol):
         self.chunks = []
         self.messages = []
         self.in_transfer_state = False
+        # Optional future, set by the client (connect) mode, that gets resolved
+        # when the connection is lost so the caller can reconnect. Stays None
+        # in server (listen) mode, where each connection is independent.
+        self.on_connection_lost = kwargs.get("on_connection_lost", None)
 
     def connection_made(self, transport):
         """Called when a connection is made.
@@ -258,4 +262,8 @@ class ASTMProtocol(asyncio.Protocol):
         """Called when the connection is lost or closed.
         """
         logger.warning("Lost connection for {!s}".format(self.client))
-        self.close_connection()
+        self.cancel_timer()
+        self.discard_env()
+        # Notify client (connect) mode so it can reconnect
+        if self.on_connection_lost and not self.on_connection_lost.done():
+            self.on_connection_lost.set_result(ex)

--- a/src/senaite/astm/server.py
+++ b/src/senaite/astm/server.py
@@ -25,6 +25,40 @@ async def consume(queue, callback=None):
             callback(message)
 
 
+async def connect_forever(loop, host, port, protocol_factory, reconnect_delay):
+    """Client (connect) mode main coroutine.
+
+    Actively opens an outbound connection to an instrument or serial-to-LAN
+    gateway at ``host:port`` (useful when the device is configured as a passive
+    TCP server and expects the LIS to initiate the connection). Keeps the
+    connection open and transparently reconnects when it drops.
+    """
+    while True:
+        # Future resolved by the protocol when the connection is lost
+        on_connection_lost = loop.create_future()
+        try:
+            logger.info(
+                'Connecting to instrument at {}:{} ...'.format(host, port))
+            await loop.create_connection(
+                lambda: protocol_factory(on_connection_lost),
+                host=host, port=port)
+        except OSError as exc:
+            logger.warning(
+                'Connection to {}:{} failed: {}. Retrying in {}s ...'.format(
+                    host, port, exc, reconnect_delay))
+            await asyncio.sleep(reconnect_delay)
+            continue
+
+        logger.info('Connected to instrument at {}:{}'.format(host, port))
+        logger.info('ASTM client ready to receive messages ...')
+        # Block until the connection drops, then reconnect
+        await on_connection_lost
+        logger.warning(
+            'Connection to {}:{} lost. Reconnecting in {}s ...'.format(
+                host, port, reconnect_delay))
+        await asyncio.sleep(reconnect_delay)
+
+
 def main():
     # Argument parser
     parser = argparse.ArgumentParser(
@@ -53,6 +87,23 @@ def main():
         '--output',
         type=str,
         help='Output directory to write full messages')
+
+    astm_group.add_argument(
+        '--connect',
+        type=str,
+        default=None,
+        metavar='HOST:PORT',
+        help='Client mode: actively connect OUT to an instrument or '
+             'serial-to-LAN gateway at HOST:PORT instead of listening. Use '
+             'this when the device is a passive TCP server and expects the '
+             'LIS to initiate the connection. Mutually exclusive with '
+             '--listen/--port.')
+
+    astm_group.add_argument(
+        '--reconnect-delay',
+        type=int,
+        default=5,
+        help='Seconds to wait before (re)connecting in --connect mode')
 
     lims_group.add_argument(
         '-u',
@@ -167,6 +218,31 @@ def main():
     queue = asyncio.Queue()
     loop.create_task(consume(queue, callback=dispatch_astm_message))
 
+    if args.connect:
+        # CLIENT (connect) mode: actively connect out to the instrument/gateway
+        host, sep, port = args.connect.partition(':')
+        if not sep or not host or not port:
+            logger.error('--connect requires the format HOST:PORT')
+            return sys.exit(-1)
+
+        def protocol_factory(on_connection_lost):
+            return ASTMProtocol(
+                queue=queue,
+                message_format=args.message_format,
+                on_connection_lost=on_connection_lost)
+
+        try:
+            loop.run_until_complete(
+                connect_forever(loop, host, int(port), protocol_factory,
+                                args.reconnect_delay))
+        except KeyboardInterrupt:
+            logger.info('Shutting down client...')
+        finally:
+            loop.close()
+            logger.info('Client is now down...')
+        return
+
+    # SERVER (listen) mode
     # Create a TCP server coroutine listening on port of the host address.
     # IMPORTANT: We create a new Protocol for every connection!
     server_coro = loop.create_server(

--- a/src/senaite/astm/tests/test_astm_client.py
+++ b/src/senaite/astm/tests/test_astm_client.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Client (connect) mode tests.
+
+In client mode senaite.astm actively connects OUT to an instrument or
+serial-to-LAN gateway that behaves as a passive TCP server (e.g. a Lantronix
+configured with "Accept Incoming = Yes" / "Active Connect = None"). This is the
+inverse of the server tests: here the *instrument* listens and senaite.astm
+initiates the connection, then plays the receiver side of the ASTM handshake.
+"""
+
+import asyncio
+import json
+
+from senaite.astm import logger
+from senaite.astm.constants import ACK
+from senaite.astm.constants import ENQ
+from senaite.astm.constants import EOT
+from senaite.astm.protocol import ASTMProtocol
+from senaite.astm.server import connect_forever
+from senaite.astm.tests.base import ASTMTestBase
+
+FIXTURE = "cobas_c111.txt"
+
+
+class ASTMClientTest(ASTMTestBase):
+    """senaite.astm as the TCP client connecting to a passive instrument."""
+
+    PORT = 7984
+
+    async def asyncSetUp(self):
+        logger.info("\n------------> asyncSetUp client")
+        self.loop = asyncio.get_event_loop()
+        self.queue = asyncio.Queue()
+        path = self.get_instrument_file_path(FIXTURE)
+        self.data = self.read_file_lines(path)
+        # Stand up the fake passive instrument (it listens, we connect to it)
+        self.instrument = await asyncio.start_server(
+            self.instrument_handler, host=self.HOST, port=self.PORT)
+
+    async def asyncTearDown(self):
+        self.instrument.close()
+        await self.instrument.wait_closed()
+
+    async def instrument_handler(self, reader, writer):
+        """Play the instrument (sender) side: ENQ -> frames -> EOT."""
+        writer.write(ENQ)
+        await writer.drain()
+        if await reader.readexactly(1) != ACK:
+            writer.close()
+            return
+        for line in self.data:
+            writer.write(line)
+            await writer.drain()
+            await reader.readexactly(1)  # ACK per frame
+        writer.write(EOT)
+        await writer.drain()
+        writer.close()
+
+    def protocol_factory(self, on_connection_lost):
+        return ASTMProtocol(
+            queue=self.queue,
+            message_format="json",
+            on_connection_lost=on_connection_lost)
+
+    def start_client(self):
+        return self.loop.create_task(
+            connect_forever(
+                self.loop, self.HOST, self.PORT,
+                self.protocol_factory, reconnect_delay=1))
+
+    async def test_client_collects_envelope(self):
+        """The client connects out and a full session lands on the queue
+        as the same JSON envelope the server mode produces."""
+        logger.info("\n------------> TEST: client_collects_envelope")
+        task = self.start_client()
+        try:
+            payload = await asyncio.wait_for(self.queue.get(), timeout=5)
+        finally:
+            task.cancel()
+        envelope = json.loads(payload)
+        self.assertIn("metadata", envelope)
+        self.assertIn("H", envelope)
+        self.assertIn("astm", envelope["metadata"])
+
+    async def test_client_reconnects_after_drop(self):
+        """After the instrument closes the socket, the client reconnects
+        and collects the next session."""
+        logger.info("\n------------> TEST: client_reconnects_after_drop")
+        task = self.start_client()
+        try:
+            first = await asyncio.wait_for(self.queue.get(), timeout=5)
+            # instrument closed after EOT -> client reconnects (1s) and the
+            # instrument serves a second session
+            second = await asyncio.wait_for(self.queue.get(), timeout=8)
+        finally:
+            task.cancel()
+        self.assertTrue(first)
+        self.assertTrue(second)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite.astm` currently runs only as a TCP **server** (`server.py` is built on `loop.create_server(...)`), so it always waits for the instrument — or its serial-to-LAN gateway — to connect *in*.

Some gateways are configured as **passive TCP servers** themselves (they only *accept* connections, they never dial out) and therefore expect the LIS to **initiate** the connection. A real-world example: an Abbott ARCHITECT ci4100 behind a Lantronix UDS1100 with `Accept Incoming = Yes` / `Active Connect = None`. In that topology both ends are passive listeners, no socket is ever established, and not a single byte (not even `<ENQ>`) reaches the server.

This PR adds a **client (connect) mode** so `senaite.astm` can actively open the outbound connection to such a device, while reusing the exact same `ASTMProtocol` receiver logic.

### What changed

- `server.py`: new `--connect HOST:PORT` mode (mutually exclusive with `--listen/--port`) that connects out to the instrument/gateway via `loop.create_connection(...)`, plus `--reconnect-delay` (default `5s`) for automatic reconnection when the link drops. Server (listen) mode is unchanged and remains the default.
- `protocol.py`: `ASTMProtocol` gains an optional `on_connection_lost` future (defaults to `None`) that `connection_lost` resolves, letting the connect loop detect drops and reconnect. In server mode it stays `None` — no behavior change.
- `tests/test_astm_client.py`: covers message reception and reconnect-after-drop by standing up a passive fake instrument that the client connects to.

## Current behavior before PR

`senaite.astm` can only listen for incoming connections. It cannot integrate with an instrument or gateway that is itself passive and requires the LIS to initiate the connection.

## Desired behavior after PR is merged

`senaite.astm --connect HOST:PORT` actively connects out to the instrument / gateway and processes messages with the same protocol/queue/wrapper pipeline as server mode, reconnecting automatically if the connection is lost.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
