### PR TITLE
senaite-astm-server: add --admin-port for a read-only HTTP /stats endpoint (uptime, sessions, dispatches)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 -----
 
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file
+- senaite-astm-server: add --admin-port for a read-only HTTP /stats endpoint (uptime, sessions, dispatches)
 - senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
 - senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS

--- a/src/senaite/astm/admin.py
+++ b/src/senaite/astm/admin.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Read-only admin HTTP endpoint for senaite-astm-server.
+
+A tiny asyncio TCP server that answers `GET /stats` with a JSON
+snapshot of the server's runtime counters: uptime, active session
+count, frame batches dispatched. A UI on top of senaite.astm can
+poll this without screen-scraping the log file.
+
+Intentionally bare:
+
+- No external deps. The HTTP response is hand-rolled HTTP/1.1.
+- No authentication. Bind to localhost or an internal interface.
+- No routes other than `/stats`. Everything else returns 404.
+
+Stats are tracked in a single shared :class:`AdminStats` instance
+the server hands to both the pipeline (via callbacks) and the
+admin protocol.
+"""
+
+import json
+import time
+
+from senaite.astm import logger
+
+
+class AdminStats(object):
+    """Mutable counter bag the server updates and the admin
+    endpoint reads. Plain attributes — no locks; asyncio is
+    single-threaded."""
+
+    def __init__(self):
+        self.started_at = time.time()
+        self.active_sessions = 0
+        self.frames_dispatched = 0
+        self.last_dispatch_at = None
+
+    def session_opened(self):
+        self.active_sessions += 1
+
+    def session_closed(self):
+        if self.active_sessions > 0:
+            self.active_sessions -= 1
+
+    def frames_in(self):
+        self.frames_dispatched += 1
+        self.last_dispatch_at = time.time()
+
+    def snapshot(self):
+        now = time.time()
+        return {
+            "uptime_seconds": round(now - self.started_at, 3),
+            "active_sessions": self.active_sessions,
+            "frames_dispatched": self.frames_dispatched,
+            "last_dispatch_at": self.last_dispatch_at,
+        }
+
+
+def render_stats_response(stats):
+    """Hand-rolled HTTP/1.1 response for `GET /stats`. Returns
+    bytes; the caller writes them on the connection and closes."""
+    body = json.dumps(stats.snapshot()).encode("utf-8")
+    headers = (
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: %d\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ) % len(body)
+    return headers.encode("utf-8") + body
+
+
+def render_not_found():
+    body = b"not found\n"
+    headers = (
+        "HTTP/1.1 404 Not Found\r\n"
+        "Content-Type: text/plain\r\n"
+        "Content-Length: %d\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ) % len(body)
+    return headers.encode("utf-8") + body
+
+
+async def _handle(reader, writer, stats):
+    """Handle one admin HTTP request. Reads only the request line;
+    ignores headers. Returns either the stats JSON or 404."""
+    try:
+        request_line = await reader.readline()
+    except Exception:
+        writer.close()
+        return
+    parts = request_line.split()
+    if len(parts) >= 2 and parts[0] == b"GET" and parts[1] == b"/stats":
+        writer.write(render_stats_response(stats))
+    else:
+        writer.write(render_not_found())
+    try:
+        await writer.drain()
+    except Exception:
+        pass
+    writer.close()
+
+
+async def start_admin_server(host, port, stats):
+    """Open the admin listener and return the asyncio Server.
+
+    The caller is expected to close the server on shutdown
+    (`server.close()` + `await server.wait_closed()`).
+    """
+    import asyncio
+
+    server = await asyncio.start_server(
+        lambda r, w: _handle(r, w, stats),
+        host=host, port=port)
+    for sock in server.sockets:
+        ip, port = sock.getsockname()[:2]
+        logger.info("Admin endpoint on http://%s:%s/stats", ip, port)
+    return server

--- a/src/senaite/astm/cli/astm_server.py
+++ b/src/senaite/astm/cli/astm_server.py
@@ -16,6 +16,8 @@ import asyncio
 import os
 
 from senaite.astm import logger
+from senaite.astm.admin import AdminStats
+from senaite.astm.admin import start_admin_server
 from senaite.astm.cli import _runtime
 from senaite.astm.core.lims import LimsPushHandler
 from senaite.astm.core.output import DiskCaptureHandler
@@ -40,6 +42,19 @@ def build_arg_parser():
     astm_group.add_argument(
         "-o", "--output", type=str,
         help="Output directory to write full messages")
+    astm_group.add_argument(
+        "--admin-port", type=int, default=None,
+        help="Open a read-only HTTP admin endpoint on this port "
+             "(GET /stats returns JSON: uptime, active sessions, "
+             "frames dispatched). Off by default. The admin "
+             "listener binds to --admin-listen; set that to a "
+             "non-public interface — no authentication is "
+             "performed.")
+
+    astm_group.add_argument(
+        "--admin-listen", type=str, default="127.0.0.1",
+        help="Bind address for the --admin-port endpoint.")
+
     astm_group.add_argument(
         "--shutdown-grace-seconds", type=int,
         default=_runtime.DEFAULT_SHUTDOWN_GRACE_SECONDS,
@@ -109,6 +124,15 @@ async def amain(args, stop_event=None):
         logger.info("Starting server on {}:{}".format(ip, port))
     logger.info("ASTM server ready to handle connections ...")
 
+    admin_server = None
+    if getattr(args, "admin_port", None):
+        stats = AdminStats()
+        # When stats hooks are wired into the protocol /
+        # pipeline, this is where the wrapping happens. The
+        # current minimum is to surface uptime + last_dispatch.
+        admin_server = await start_admin_server(
+            args.admin_listen, args.admin_port, stats)
+
     if stop_event is None:
         stop_event = asyncio.Event()
     _runtime.install_shutdown_handlers(loop, stop_event)
@@ -117,6 +141,9 @@ async def amain(args, stop_event=None):
         await stop_event.wait()
     finally:
         logger.info("Shutting down server...")
+        if admin_server is not None:
+            admin_server.close()
+            await admin_server.wait_closed()
         server.close()
         await server.wait_closed()
         await _runtime.drain_tasks(task_set, args.shutdown_grace_seconds)

--- a/src/senaite/astm/tests/test_admin.py
+++ b/src/senaite/astm/tests/test_admin.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Tests for the read-only admin HTTP endpoint."""
+
+import asyncio
+import json
+import unittest
+
+from senaite.astm.admin import AdminStats
+from senaite.astm.admin import render_not_found
+from senaite.astm.admin import render_stats_response
+from senaite.astm.admin import start_admin_server
+
+
+class AdminStatsTest(unittest.TestCase):
+
+    def test_initial_snapshot_has_expected_keys(self):
+        snap = AdminStats().snapshot()
+        self.assertIn("uptime_seconds", snap)
+        self.assertIn("active_sessions", snap)
+        self.assertIn("frames_dispatched", snap)
+        self.assertIn("last_dispatch_at", snap)
+        self.assertGreaterEqual(snap["uptime_seconds"], 0)
+        self.assertEqual(snap["active_sessions"], 0)
+        self.assertEqual(snap["frames_dispatched"], 0)
+        self.assertIsNone(snap["last_dispatch_at"])
+
+    def test_session_counters_balance(self):
+        stats = AdminStats()
+        stats.session_opened()
+        stats.session_opened()
+        stats.session_closed()
+        self.assertEqual(stats.snapshot()["active_sessions"], 1)
+
+    def test_close_never_goes_below_zero(self):
+        stats = AdminStats()
+        stats.session_closed()
+        self.assertEqual(stats.snapshot()["active_sessions"], 0)
+
+    def test_frame_dispatch_increments(self):
+        stats = AdminStats()
+        stats.frames_in()
+        stats.frames_in()
+        snap = stats.snapshot()
+        self.assertEqual(snap["frames_dispatched"], 2)
+        self.assertIsNotNone(snap["last_dispatch_at"])
+
+
+class RenderResponseTest(unittest.TestCase):
+
+    def test_stats_response_is_valid_http(self):
+        stats = AdminStats()
+        raw = render_stats_response(stats)
+        self.assertTrue(raw.startswith(b"HTTP/1.1 200 OK\r\n"))
+        body = raw.split(b"\r\n\r\n", 1)[1]
+        snap = json.loads(body.decode("utf-8"))
+        self.assertIn("uptime_seconds", snap)
+
+    def test_not_found_response(self):
+        raw = render_not_found()
+        self.assertTrue(raw.startswith(b"HTTP/1.1 404"))
+
+
+class AdminServerIntegrationTest(unittest.TestCase):
+    """Boot the admin listener on an ephemeral port, hit /stats
+    and /missing, confirm the responses."""
+
+    def test_endpoint_roundtrip(self):
+        async def run():
+            stats = AdminStats()
+            stats.session_opened()
+            stats.frames_in()
+            server = await start_admin_server("127.0.0.1", 0, stats)
+            port = server.sockets[0].getsockname()[1]
+            try:
+                # GET /stats
+                reader, writer = await asyncio.open_connection(
+                    "127.0.0.1", port)
+                writer.write(b"GET /stats HTTP/1.1\r\nHost: x\r\n\r\n")
+                await writer.drain()
+                response = await reader.read()
+                writer.close()
+                self.assertIn(b"200 OK", response)
+                body = response.split(b"\r\n\r\n", 1)[1]
+                payload = json.loads(body.decode("utf-8"))
+                self.assertEqual(payload["active_sessions"], 1)
+                self.assertEqual(payload["frames_dispatched"], 1)
+
+                # GET /other -> 404
+                reader, writer = await asyncio.open_connection(
+                    "127.0.0.1", port)
+                writer.write(b"GET /other HTTP/1.1\r\n\r\n")
+                await writer.drain()
+                response = await reader.read()
+                writer.close()
+                self.assertIn(b"404", response)
+            finally:
+                server.close()
+                await server.wait_closed()
+
+        asyncio.run(run())
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(AdminStatsTest))
+    suite.addTests(loader.loadTestsFromTestCase(RenderResponseTest))
+    suite.addTests(
+        loader.loadTestsFromTestCase(AdminServerIntegrationTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

A UI on top of senaite.astm needs a way to ask the server "are you alive?", "how many sessions are active?", "when did you last receive frames?" — without screen-scraping the log file or shelling out to `lsof`.

## Current behavior before PR

The only signal about the server's runtime state is its log output. There is no machine-readable endpoint.

## Desired behavior after PR is merged

```
senaite-astm-server -p 4010 --admin-port 4011

curl http://127.0.0.1:4011/stats
{"uptime_seconds": 12.4, "active_sessions": 0, "frames_dispatched": 0, "last_dispatch_at": null}
```

- `--admin-port` is off by default.
- `--admin-listen` defaults to `127.0.0.1` — the endpoint is unauthenticated.
- Hand-rolled HTTP/1.1 over `asyncio.start_server`. No external deps.
- The stats bag (`AdminStats`) is in place and ready for the protocol / pipeline to hook into; this PR wires up the listener and the counter shape. A follow-up will wire `session_opened` / `frames_in` from the ASTM protocol callbacks.

## Tests

- `AdminStats` snapshot shape, session balance, close-below-zero guard, frame counter.
- `render_stats_response` / `render_not_found` produce valid HTTP/1.1.
- End-to-end: boot the listener on an ephemeral port, GET `/stats` and `/other`, confirm responses.