### PR TITLE
senaite-astm-server: add --capture-only to persist captures without forwarding them to the LIMS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 - senaite-astm-send: add --validate-only to parse + envelope-check captures without pushing to a LIMS
 - senaite-astm-send: add --scrub-phi to redact patient identifiers in the JSON envelope before pushing
 - senaite-astm-inspect: new read-only CLI for instrument / summary / diff over captured ASTM files
+- senaite-astm-server: add --capture-only to persist captures without forwarding them to the LIMS
 - senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
 - senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
 - senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS

--- a/src/senaite/astm/cli/astm_server.py
+++ b/src/senaite/astm/cli/astm_server.py
@@ -56,6 +56,14 @@ def build_arg_parser():
         help="Bind address for the --admin-port endpoint.")
 
     astm_group.add_argument(
+        "--capture-only", action="store_true",
+        help="Accept connections and persist captures, but skip "
+             "the LIMS push step even when --url is given. Useful "
+             "for a hold-and-review workflow where an operator (or "
+             "a UI on top of this server) wants to inspect messages "
+             "before they propagate to the LIMS. Requires --output.")
+
+    astm_group.add_argument(
         "--shutdown-grace-seconds", type=int,
         default=_runtime.DEFAULT_SHUTDOWN_GRACE_SECONDS,
         help="Seconds to wait for in-flight handler tasks to "
@@ -78,7 +86,7 @@ def build_pipeline(args, session):
     handlers = []
     if args.output:
         handlers.append(DiskCaptureHandler(os.path.abspath(args.output)))
-    if session is not None:
+    if session is not None and not getattr(args, "capture_only", False):
         handlers.append(LimsPushHandler(
             session,
             retries=args.retries,
@@ -167,7 +175,15 @@ def main():
 
     _runtime.configure_logging(args)
     _runtime.validate_output(args.output)
-    args.session = _runtime.validate_lims(args.url)
+    if args.capture_only and not args.output:
+        parser.error("--capture-only requires --output")
+    if args.capture_only:
+        logger.info(
+            "Capture-only mode: LIMS push disabled; "
+            "captures persisted to %s", args.output)
+        args.session = None
+    else:
+        args.session = _runtime.validate_lims(args.url)
 
     try:
         asyncio.run(amain(args))

--- a/src/senaite/astm/tests/test_server_capture_only.py
+++ b/src/senaite/astm/tests/test_server_capture_only.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Tests for `senaite-astm-server --capture-only`.
+
+The flag turns the server into a hold-and-review pipeline: it
+accepts connections, writes captures to disk, and skips the LIMS
+push step even when --url is supplied.
+"""
+
+import argparse
+import unittest
+
+from senaite.astm.cli.astm_server import build_arg_parser
+from senaite.astm.cli.astm_server import build_pipeline
+from senaite.astm.core.lims import LimsPushHandler
+from senaite.astm.core.output import DiskCaptureHandler
+
+
+class _FakeSession(object):
+    pass
+
+
+def _parse(extra):
+    parser = build_arg_parser()
+    return parser.parse_args(extra)
+
+
+class BuildPipelineTest(unittest.TestCase):
+
+    def test_capture_only_drops_lims_push(self):
+        args = _parse([
+            "-o", "/tmp/out",
+            "-u", "http://admin:secret@localhost/senaite",
+            "--capture-only",
+        ])
+        pipeline = build_pipeline(args, _FakeSession())
+        kinds = [type(h) for h in pipeline.handlers]
+        self.assertIn(DiskCaptureHandler, kinds)
+        self.assertNotIn(LimsPushHandler, kinds)
+
+    def test_default_includes_lims_push_when_session_present(self):
+        args = _parse([
+            "-o", "/tmp/out",
+            "-u", "http://admin:secret@localhost/senaite",
+        ])
+        pipeline = build_pipeline(args, _FakeSession())
+        kinds = [type(h) for h in pipeline.handlers]
+        self.assertIn(LimsPushHandler, kinds)
+
+
+class ParserTest(unittest.TestCase):
+
+    def test_capture_only_flag_defaults_off(self):
+        args = _parse([])
+        self.assertFalse(args.capture_only)
+
+    def test_capture_only_flag_sets_true(self):
+        args = _parse(["--capture-only"])
+        self.assertTrue(args.capture_only)
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(BuildPipelineTest))
+    suite.addTests(loader.loadTestsFromTestCase(ParserTest))
+    return suite

--- a/src/senaite/astm/tests/test_server_capture_only.py
+++ b/src/senaite/astm/tests/test_server_capture_only.py
@@ -6,7 +6,6 @@ accepts connections, writes captures to disk, and skips the LIMS
 push step even when --url is supplied.
 """
 
-import argparse
 import unittest
 
 from senaite.astm.cli.astm_server import build_arg_parser


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When commissioning a new device — or wiring up a new consumer adapter — it is useful to run the server in a hold-and-review mode where every capture lands on disk but nothing propagates to the LIMS. Today the only way to get that effect is to omit `--url` entirely, which loses the ability to switch back to forwarding without restarting.

## Current behavior before PR

The pipeline always pushes to the LIMS when `--url` is set. No middle ground.

## Desired behavior after PR is merged

```
senaite-astm-server -p 4010 -o ./hold -u http://admin:secret@localhost/senaite --capture-only
```

- Accepts connections, persists captures to `./hold/`.
- Skips the LIMS push step even though `--url` was supplied.
- Requires `--output` (errors out otherwise — there has to be somewhere to hold the captures).
- Logs `Capture-only mode: LIMS push disabled` on startup so the runtime is obvious in the logfile.
- When `--capture-only` is set, the LIMS session is not validated, so the server boots cleanly even when the LIMS is offline.

## Tests

- `build_pipeline` returns no `LimsPushHandler` when `--capture-only` is set.
- Default invocation still includes the `LimsPushHandler`.
- Flag defaults to off, sets to true when supplied.