### PR TITLE
core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.0
 -----
 
+- core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 2.0.0
 -----
 
-- core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
+- #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/src/senaite/astm/core/lims.py
+++ b/src/senaite/astm/core/lims.py
@@ -17,6 +17,19 @@ DEFAULT_RETRIES = 3
 DEFAULT_DELAY = 5
 DEFAULT_CONSUMER = "senaite.lis2a.import"
 
+# `requests` timeout tuple: (connect, read).
+#
+# Without an explicit timeout `requests` blocks indefinitely on a
+# stalled response. In a long-running pipeline that means a hung
+# Zope worker on the LIMS side pins an asyncio thread-pool worker
+# per push, `task_set` grows unbounded, and the admin /stats
+# endpoint keeps reporting "healthy" until the process OOMs or
+# saturates its thread pool. 10s to open the socket, 60s for the
+# LIMS to produce a response — generous enough that a busy Zope
+# worker handling a real payload still finishes, tight enough that
+# a wedged worker is recycled within a minute.
+DEFAULT_HTTP_TIMEOUT = (10, 60)
+
 
 class SenaiteError(Exception):
     """Base class for SENAITE LIMS push errors."""
@@ -95,16 +108,22 @@ class Session(object):
         logger.info("Session established ('{}') with '{}'"
                     .format(self.username, self.url))
 
-    def post(self, endpoint, payload):
+    def post(self, endpoint, payload, timeout=DEFAULT_HTTP_TIMEOUT):
         """Send a POST request to SENAITE.
 
+        :param timeout: `requests` timeout passed through to the
+            session. Defaults to :data:`DEFAULT_HTTP_TIMEOUT` —
+            never `None`. A blocking POST behind a wedged Zope
+            worker would otherwise pin a thread-pool worker and
+            grow the pipeline's task set without bound.
         :returns: Parsed JSON response.
         :raises SenaiteUnreachableError: on connection-level failures.
         :raises SenaiteHTTPError: on non-200 responses.
         """
         url = self.get_url(endpoint)
         try:
-            response = self._session.post(url, data=payload)
+            response = self._session.post(
+                url, data=payload, timeout=timeout)
         except requests.RequestException as exc:
             raise SenaiteUnreachableError(
                 "Could not POST to {}: {}".format(url, exc)) from exc
@@ -116,7 +135,7 @@ class Session(object):
 
         return response.json()
 
-    def get(self, endpoint, timeout=60):
+    def get(self, endpoint, timeout=DEFAULT_HTTP_TIMEOUT):
         """Fetch the given endpoint and return parsed JSON.
 
         :raises SenaiteUnreachableError: on connection-level failures.

--- a/src/senaite/astm/tests/test_lims.py
+++ b/src/senaite/astm/tests/test_lims.py
@@ -125,6 +125,29 @@ class SessionAuthTest(unittest.TestCase):
             Session(URL).post("push", {"x": 1})
         self.assertEqual(ctx.exception.status_code, 503)
 
+    def test_post_passes_default_timeout(self):
+        """A blocking POST behind a hung Zope worker would pin a
+        thread-pool worker indefinitely. Confirm the session always
+        passes a timeout tuple through to requests."""
+        from senaite.astm.core.lims import DEFAULT_HTTP_TIMEOUT
+        session = Session(URL)
+        with patch.object(session._session, "post") as fake_post:
+            fake_post.return_value = MagicMock(
+                status_code=200, json=lambda: {})
+            session.post("push", {"x": 1})
+        kwargs = fake_post.call_args.kwargs
+        self.assertEqual(kwargs.get("timeout"), DEFAULT_HTTP_TIMEOUT)
+
+    def test_get_passes_default_timeout(self):
+        from senaite.astm.core.lims import DEFAULT_HTTP_TIMEOUT
+        session = Session(URL)
+        with patch.object(session._session, "get") as fake_get:
+            fake_get.return_value = MagicMock(
+                status_code=200, json=lambda: {})
+            session.get("anything")
+        kwargs = fake_get.call_args.kwargs
+        self.assertEqual(kwargs.get("timeout"), DEFAULT_HTTP_TIMEOUT)
+
 
 class PushResultTest(unittest.TestCase):
     """PushResult is the documented return type of post_to_senaite."""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pre-production review finding: `Session.post` had no timeout, so a stalled LIMS response would block an `asyncio.to_thread` worker indefinitely. Long-running deployments would gradually exhaust the thread pool and grow `task_set` without bound.

## Current behavior before PR

```python
response = self._session.post(url, data=payload)   # no timeout
```

`Session.get` defaulted to `timeout=60`; `Session.post` was unbounded.

## Desired behavior after PR is merged

Both methods default to `DEFAULT_HTTP_TIMEOUT = (10, 60)` — connect / read seconds — and accept an override. The constant is at module top with a comment explaining the rationale.

## Tests

- Existing 21 tests still pass.
- New: `test_post_passes_default_timeout` asserts `Session.post` forwards `DEFAULT_HTTP_TIMEOUT` to `requests`.
- New: `test_get_passes_default_timeout` asserts the same for `Session.get`.