### PR TITLE
senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
-- senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
+- #65 senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
+- senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -32,22 +32,30 @@ from senaite.astm.utils import parse_capture
 from senaite.astm.utils import rebuild_checksums
 from senaite.astm.wrapper import Wrapper
 
-# Conservative default set of P-record keys that almost always
-# carry identifying / medical information. The full P record has
-# 30+ fields (see senaite.astm.records.PatientRecord); this set
-# targets the obvious ones. Use --scrub-phi-extra-fields to add
-# vendor-specific keys not covered here.
-PHI_KEYS = (
-    "name",
-    "maiden_name",
-    "birthdate",
-    "address",
-    "phone",
-    "id",
-    "physician_id",
-    "diagnosis",
-    "medication",
-)
+# Allowlist of P-record keys treated as non-PHI under --scrub-phi.
+#
+# The ASTM P record (see senaite.astm.records.PatientRecord) has
+# 30+ fields, most of which carry identifiers, dates, addresses or
+# medical free-text. A redact-by-allowlist policy is the only safe
+# default for a privacy-guarantee flag: a previous version of this
+# module shipped a hand-picked PHI_KEYS list which missed obvious
+# identifiers (practice_id, laboratory_id, admission_date,
+# diagnostic_code, hospital_*) and would have leaked them through.
+#
+# Kept under the allowlist: record metadata (type, seq), clinical
+# demographics typically retained for context (sex, race), and
+# clinical observations (height, weight, diet). The ASTM-reserved
+# placeholder is also kept since it never carries a value.
+PHI_NON_PHI_KEYS = frozenset((
+    "type",
+    "seq",
+    "sex",
+    "race",
+    "height",
+    "weight",
+    "diet",
+    "reserved",
+))
 PHI_REDACTION = "<REDACTED>"
 
 # Record buckets the envelope splits frames into. Used to validate
@@ -59,7 +67,7 @@ RECORD_TYPES = ("H", "P", "O", "R", "C", "M", "L", "Q")
 
 def _file_to_message(fh, message_format, rebuild=False,
                      substitutions=None,
-                     scrub_phi=False, phi_extra=(),
+                     scrub_phi=False, phi_keep=(),
                      keep_records=None, drop_records=None):
     """Read a captured ASTM file and produce one message for
     `post_to_senaite`.
@@ -84,13 +92,18 @@ def _file_to_message(fh, message_format, rebuild=False,
     that changes a frame body invalidates the trailing checksum,
     so the typical companion flag is `--rebuild-checksums`.
 
-    `scrub_phi=True` replaces the values of well-known
-    patient-identifying keys in every P record with `<REDACTED>`
-    before the envelope is serialised. Only the parsed-JSON path
-    can be scrubbed safely; raw ASTM bytes and the flat LIS2-A
-    text in `metadata.*` are not rewritten, so the caller should
-    use `-m json`. `phi_extra` adds vendor-specific keys to the
-    default set (see :data:`PHI_KEYS`).
+    `scrub_phi=True` redacts every P-record value whose key is
+    NOT in the non-PHI allowlist :data:`PHI_NON_PHI_KEYS`. The
+    allowlist policy is the only safe default for a privacy
+    flag — the ASTM P record has 30+ fields and a hand-picked
+    blocklist will almost always miss something (an earlier
+    version of this code did exactly that, missing practice_id,
+    laboratory_id, admission_date, diagnostic_code and several
+    hospital_* fields). Only the parsed-JSON path can be
+    scrubbed safely; raw ASTM bytes and the flat LIS2-A text in
+    `metadata.*` are not rewritten, so the caller should use
+    `-m json`. `phi_keep` extends the allowlist with
+    vendor-specific non-identifying fields.
 
     `keep_records` / `drop_records` (mutually exclusive; pass at
     most one) trim the parsed envelope's per-type buckets before
@@ -111,7 +124,7 @@ def _file_to_message(fh, message_format, rebuild=False,
     frames = parse_capture(raw)
     envelope = Wrapper(frames).to_envelope()
     if scrub_phi:
-        _scrub_envelope_phi(envelope, phi_extra)
+        _scrub_envelope_phi(envelope, phi_keep)
     if keep_records or drop_records:
         _filter_envelope_records(envelope, keep_records, drop_records)
     return serialize_envelope(envelope, message_format)
@@ -148,19 +161,21 @@ def _parse_substitution(value):
     return (old.encode("latin-1"), new.encode("latin-1"))
 
 
-def _scrub_envelope_phi(envelope, extra_keys=()):
-    """Replace the values of PHI keys in every P record of
-    `envelope` with :data:`PHI_REDACTION`, in place.
+def _scrub_envelope_phi(envelope, keep_keys=()):
+    """Redact every P-record value whose key is not in the
+    non-PHI allowlist, in place. The allowlist defaults to
+    :data:`PHI_NON_PHI_KEYS`; `keep_keys` extends it for
+    vendor-specific non-identifying fields.
 
     Also drops the verbatim flat-text payloads in `metadata.astm`
     and `metadata.lis2a` so a JSON-scrubbed message can't be
     pulled back to its un-scrubbed raw form by a downstream
     consumer that only looks at metadata.
     """
-    keys = set(PHI_KEYS) | set(extra_keys)
+    allowed = PHI_NON_PHI_KEYS | frozenset(keep_keys)
     for patient in envelope.P:
         for key in list(patient.keys()):
-            if key in keys and patient[key]:
+            if key not in allowed and patient[key]:
                 patient[key] = PHI_REDACTION
     if envelope.metadata.astm:
         envelope.metadata.astm = ""
@@ -249,11 +264,14 @@ def main():
              "the raw / flat formats cannot be rewritten safely.")
 
     astm_group.add_argument(
-        "--scrub-phi-extra-field", dest="phi_extra",
+        "--scrub-phi-keep-field", dest="phi_keep",
         action="append", default=[], metavar="KEY",
-        help="Additional P-record key to redact under --scrub-phi. "
-             "Repeatable; vendor-specific keys not covered by the "
-             "default set go here.")
+        help="Additional P-record key to KEEP unredacted under "
+             "--scrub-phi (vendor-specific non-identifying field "
+             "that isn't part of the default allowlist). "
+             "Repeatable. The default allowlist is "
+             "type/seq/sex/race/height/weight/diet/reserved; "
+             "everything else in the P record is redacted.")
 
     astm_group.add_argument(
         "--filter-records", type=_parse_record_list, default=None,
@@ -376,7 +394,7 @@ def main():
                     rebuild=args.rebuild_checksums,
                     substitutions=args.substitutions,
                     scrub_phi=args.scrub_phi,
-                    phi_extra=args.phi_extra,
+                    phi_keep=args.phi_keep,
                     keep_records=args.filter_records,
                     drop_records=args.drop_records)))
         except Exception as exc:

--- a/src/senaite/astm/tests/test_sender_scrub_phi.py
+++ b/src/senaite/astm/tests/test_sender_scrub_phi.py
@@ -3,9 +3,11 @@
 
 The flag redacts patient-identifying fields in the typed envelope
 before serialisation so real captures can be replayed against a
-dev / staging LIMS without leaking PHI. Only the JSON output is
-scrubbed; raw ASTM / LIS2-A bytes are intentionally cleared so a
-downstream consumer can't pull them back to the unredacted form.
+dev / staging LIMS without leaking PHI. The policy is redact-by-
+allowlist: everything in a P record is scrubbed unless its key is
+in :data:`PHI_NON_PHI_KEYS`. Only the JSON output is scrubbed; raw
+ASTM / LIS2-A bytes are intentionally cleared so a downstream
+consumer can't pull them back to the unredacted form.
 """
 
 import json
@@ -14,7 +16,7 @@ import unittest
 
 from senaite.astm.core.envelope import Envelope
 from senaite.astm.core.envelope import Metadata
-from senaite.astm.sender import PHI_KEYS
+from senaite.astm.sender import PHI_NON_PHI_KEYS
 from senaite.astm.sender import PHI_REDACTION
 from senaite.astm.sender import _file_to_message
 from senaite.astm.sender import _scrub_envelope_phi
@@ -25,31 +27,135 @@ DATA_DIR = os.path.join(HERE, "data")
 FIXTURE = os.path.join(DATA_DIR, "yumizen_h500.txt")
 
 
-def _envelope(scrub=False, phi_extra=()):
+def _envelope(scrub=False, phi_keep=()):
     msg = _file_to_message(
         open(FIXTURE, "rb"), "json",
-        scrub_phi=scrub, phi_extra=phi_extra)
+        scrub_phi=scrub, phi_keep=phi_keep)
     return json.loads(msg)
 
 
-class ScrubPhiTest(unittest.TestCase):
+def _full_patient():
+    """Build a P record populated across the full ASTM PatientRecord
+    schema so a scrub call exercises every field. Every value is a
+    truthy string so the truthy-check in the scrubber does not skip
+    any field accidentally."""
+    return {
+        "type": "P",
+        "seq": "1",
+        # ASTM PatientRecord fields (senaite.astm.records)
+        "practice_id": "PRX-001",
+        "laboratory_id": "LAB-002",
+        "id": "MRN-003",
+        "name": "Doe^John^A",
+        "maiden_name": "Smith",
+        "birthdate": "19800101",
+        "sex": "M",
+        "race": "human",
+        "address": "1 Main St",
+        "reserved": "rsv",
+        "phone": "+1234567890",
+        "physician_id": "DR-004",
+        "special_1": "free text",
+        "special_2": "free text 2",
+        "height": "180",
+        "weight": "75",
+        "diagnosis": "free text diagnosis",
+        "medication": "free text medication",
+        "diet": "free text diet",
+        "practice_field_1": "lab tag a",
+        "practice_field_2": "lab tag b",
+        "admission_date": "20260101",
+        "admission_status": "INP",
+        "location": "Ward 5",
+        "diagnostic_code_nature": "ICD10",
+        "diagnostic_code": "Z00.0",
+        "religion": "n/a",
+        "martial_status": "S",
+        "isolation_status": "none",
+        "language": "EN",
+        "hospital_service": "Hematology",
+        "hospital_institution": "General Hospital",
+        "dosage_category": "STD",
+    }
 
-    def test_default_phi_keys_are_redacted(self):
-        env = _envelope(scrub=True)
-        for patient in env["P"]:
-            for key in PHI_KEYS:
-                if key in patient and patient[key]:
-                    self.assertEqual(
-                        patient[key], PHI_REDACTION,
-                        "%s leaked: %r" % (key, patient[key]))
 
-    def test_non_phi_fields_pass_through_unchanged(self):
-        original = _envelope(scrub=False)
-        scrubbed = _envelope(scrub=True)
-        # Sex is not in PHI_KEYS — must not be redacted.
-        for orig, scrub in zip(original["P"], scrubbed["P"]):
-            if "sex" in orig:
-                self.assertEqual(scrub.get("sex"), orig.get("sex"))
+class ScrubPhiPolicyTest(unittest.TestCase):
+    """Allowlist policy: everything outside PHI_NON_PHI_KEYS is
+    redacted; everything inside passes through verbatim."""
+
+    def test_every_pii_field_is_redacted(self):
+        env = Envelope(metadata=Metadata())
+        env.P.append(_full_patient())
+        _scrub_envelope_phi(env)
+        patient = env.P[0]
+        for key, value in patient.items():
+            if key in PHI_NON_PHI_KEYS:
+                continue
+            self.assertEqual(
+                value, PHI_REDACTION,
+                "%s leaked: %r" % (key, value))
+
+    def test_allowlisted_fields_pass_through(self):
+        env = Envelope(metadata=Metadata())
+        original = _full_patient()
+        env.P.append(dict(original))
+        _scrub_envelope_phi(env)
+        patient = env.P[0]
+        for key in PHI_NON_PHI_KEYS:
+            if key in original:
+                self.assertEqual(
+                    patient[key], original[key],
+                    "%s was wrongly redacted" % key)
+
+    def test_phi_keep_extends_the_allowlist(self):
+        env = Envelope(metadata=Metadata())
+        env.P.append({
+            "type": "P",
+            "seq": "1",
+            "name": "Doe^John",
+            "vendor_tag": "non-identifying-value",
+        })
+        _scrub_envelope_phi(env, keep_keys=("vendor_tag",))
+        self.assertEqual(env.P[0]["name"], PHI_REDACTION)
+        self.assertEqual(env.P[0]["vendor_tag"],
+                         "non-identifying-value")
+
+    def test_known_blocklist_regression(self):
+        """The original hand-picked blocklist missed these keys —
+        the allowlist policy must cover all of them."""
+        env = Envelope(metadata=Metadata())
+        env.P.append({
+            "type": "P",
+            "seq": "1",
+            "practice_id": "PR-1",
+            "laboratory_id": "LAB-1",
+            "admission_date": "20260101",
+            "diagnostic_code": "Z00.0",
+            "hospital_institution": "General Hospital",
+            "hospital_service": "Hematology",
+            "location": "Ward 5",
+            "special_1": "free text",
+            "special_2": "free text 2",
+            "practice_field_1": "tag a",
+            "practice_field_2": "tag b",
+            "religion": "n/a",
+            "language": "EN",
+        })
+        _scrub_envelope_phi(env)
+        for key in (
+            "practice_id", "laboratory_id", "admission_date",
+            "diagnostic_code", "hospital_institution",
+            "hospital_service", "location",
+            "special_1", "special_2",
+            "practice_field_1", "practice_field_2",
+            "religion", "language",
+        ):
+            self.assertEqual(
+                env.P[0][key], PHI_REDACTION,
+                "%s leaked: %r" % (key, env.P[0][key]))
+
+
+class ScrubPhiMetadataTest(unittest.TestCase):
 
     def test_metadata_raw_payloads_are_cleared(self):
         env = _envelope(scrub=True)
@@ -66,24 +172,6 @@ class ScrubPhiTest(unittest.TestCase):
             env["metadata"].get("astm")
             or env["metadata"].get("lis2a"))
 
-    def test_extra_field_is_redacted(self):
-        # The bundled fixture's P record only has type/seq
-        # populated, so verify --scrub-phi-extra-field at the
-        # function level with a synthetic envelope.
-        env = Envelope(metadata=Metadata())
-        env.P.append({
-            "type": "P",
-            "seq": "1",
-            "name": "Doe^John",
-            "vendor_tag": "lab-internal-id-42",
-        })
-        _scrub_envelope_phi(env, extra_keys=("vendor_tag",))
-        self.assertEqual(env.P[0]["name"], PHI_REDACTION)
-        self.assertEqual(env.P[0]["vendor_tag"], PHI_REDACTION)
-        # type / seq are not in the keys set
-        self.assertEqual(env.P[0]["type"], "P")
-        self.assertEqual(env.P[0]["seq"], "1")
-
 
 class ScrubPhiNoOpTest(unittest.TestCase):
 
@@ -98,6 +186,7 @@ class ScrubPhiNoOpTest(unittest.TestCase):
 def test_suite():
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
-    suite.addTests(loader.loadTestsFromTestCase(ScrubPhiTest))
+    suite.addTests(loader.loadTestsFromTestCase(ScrubPhiPolicyTest))
+    suite.addTests(loader.loadTestsFromTestCase(ScrubPhiMetadataTest))
     suite.addTests(loader.loadTestsFromTestCase(ScrubPhiNoOpTest))
     return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pre-production review finding: the previous `--scrub-phi` blocklist `PHI_KEYS` missed many obvious patient-identifying ASTM P-record fields (full list below). For a flag whose contract is "redact PHI before pushing", missing any field by default is unsafe.

## Current behavior before PR

`PHI_KEYS` was a hand-picked blocklist of 9 names (`name`, `maiden_name`, `birthdate`, `address`, `phone`, `id`, `physician_id`, `diagnosis`, `medication`). The ASTM PatientRecord schema has 30+ fields. Any of these would leak through unredacted:

- `practice_id` (ASTM 8.1.3) — Practice-assigned patient ID
- `laboratory_id` (ASTM 8.1.4) — Laboratory-assigned patient ID
- `admission_date`, `admission_status`, `location`
- `diagnostic_code`, `diagnostic_code_nature`
- `hospital_service`, `hospital_institution`
- `special_1`, `special_2`, `practice_field_1`, `practice_field_2` (free-text vendor fields)
- `religion`, `language`, `martial_status`, `isolation_status`

## Desired behavior after PR is merged

Switch to redact-by-allowlist. The allowlist is `PHI_NON_PHI_KEYS = {type, seq, sex, race, height, weight, diet, reserved}` — record metadata plus clinical demographics typically retained for context. Everything else in a P record is replaced with `<REDACTED>`.

The companion flag is renamed:

- old: `--scrub-phi-extra-field KEY` (add to blocklist)
- new: `--scrub-phi-keep-field KEY` (extend allowlist with a vendor-specific non-identifying field)

## Tests

- `test_every_pii_field_is_redacted` parametrises over the full PatientRecord schema and asserts everything outside the allowlist is redacted.
- `test_allowlisted_fields_pass_through` confirms the allowlist round-trips unchanged.
- `test_known_blocklist_regression` explicitly asserts every previously-leaking field is now redacted.
- `test_phi_keep_extends_the_allowlist` covers the renamed CLI option.
- 8 tests pass; flake8 clean.