### PR TITLE
admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 -----
 
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
-- admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
+- #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 -----
 
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
+- admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/src/senaite/astm/admin.py
+++ b/src/senaite/astm/admin.py
@@ -17,6 +17,7 @@ the server hands to both the pipeline (via callbacks) and the
 admin protocol.
 """
 
+import asyncio
 import json
 import time
 
@@ -81,12 +82,41 @@ def render_not_found():
     return headers.encode("utf-8") + body
 
 
+#: Seconds before a half-open admin connection is dropped.
+#: A peer that opens TCP but never sends `\r\n` would otherwise
+#: park a handler task forever (slowloris-style); 5 seconds is
+#: tight for healthy peers and bounds the resource impact of a
+#: hostile one.
+ADMIN_REQUEST_TIMEOUT = 5
+
+#: Hard cap on the bytes accepted for the request line.
+#: HTTP/1.1 servers commonly cap request lines around 8 KiB; a
+#: 2 KiB cap is more than enough for `GET /stats HTTP/1.1\r\n`
+#: and refuses oversized requests with a clean failure rather
+#: than memory growth.
+ADMIN_REQUEST_LINE_LIMIT = 2048
+
+
 async def _handle(reader, writer, stats):
     """Handle one admin HTTP request. Reads only the request line;
-    ignores headers. Returns either the stats JSON or 404."""
+    ignores headers. Returns either the stats JSON or 404.
+
+    Bounded by :data:`ADMIN_REQUEST_TIMEOUT` and
+    :data:`ADMIN_REQUEST_LINE_LIMIT` so a slow or oversized peer
+    cannot park the handler task indefinitely.
+    """
     try:
-        request_line = await reader.readline()
-    except Exception:
+        request_line = await asyncio.wait_for(
+            reader.readuntil(b"\n"),
+            timeout=ADMIN_REQUEST_TIMEOUT)
+    except (asyncio.TimeoutError, asyncio.IncompleteReadError,
+            asyncio.LimitOverrunError, ConnectionError) as exc:
+        logger.debug("Admin: dropping connection (%s)", exc)
+        writer.close()
+        return
+    if len(request_line) > ADMIN_REQUEST_LINE_LIMIT:
+        logger.debug("Admin: request line over %d bytes; dropping",
+                     ADMIN_REQUEST_LINE_LIMIT)
         writer.close()
         return
     parts = request_line.split()
@@ -96,8 +126,8 @@ async def _handle(reader, writer, stats):
         writer.write(render_not_found())
     try:
         await writer.drain()
-    except Exception:
-        pass
+    except (ConnectionError, BrokenPipeError) as exc:
+        logger.debug("Admin: drain failed (%s)", exc)
     writer.close()
 
 
@@ -107,11 +137,10 @@ async def start_admin_server(host, port, stats):
     The caller is expected to close the server on shutdown
     (`server.close()` + `await server.wait_closed()`).
     """
-    import asyncio
-
     server = await asyncio.start_server(
         lambda r, w: _handle(r, w, stats),
-        host=host, port=port)
+        host=host, port=port,
+        limit=ADMIN_REQUEST_LINE_LIMIT)
     for sock in server.sockets:
         ip, port = sock.getsockname()[:2]
         logger.info("Admin endpoint on http://%s:%s/stats", ip, port)

--- a/src/senaite/astm/tests/test_admin.py
+++ b/src/senaite/astm/tests/test_admin.py
@@ -60,6 +60,41 @@ class RenderResponseTest(unittest.TestCase):
         self.assertTrue(raw.startswith(b"HTTP/1.1 404"))
 
 
+class AdminSlowlorisTest(unittest.TestCase):
+    """A peer that opens TCP but never sends `\\r\\n` must not park
+    the handler task indefinitely. The handler enforces a short
+    request timeout."""
+
+    def test_silent_peer_dropped_within_timeout(self):
+        import senaite.astm.admin as admin_mod
+
+        original_timeout = admin_mod.ADMIN_REQUEST_TIMEOUT
+        admin_mod.ADMIN_REQUEST_TIMEOUT = 0.25
+        try:
+            asyncio.run(self._run_silent_peer())
+        finally:
+            admin_mod.ADMIN_REQUEST_TIMEOUT = original_timeout
+
+    async def _run_silent_peer(self):
+        stats = AdminStats()
+        server = await start_admin_server("127.0.0.1", 0, stats)
+        port = server.sockets[0].getsockname()[1]
+        try:
+            reader, writer = await asyncio.open_connection(
+                "127.0.0.1", port)
+            # Send nothing — the handler must time out and close
+            # the connection on its side. If the timeout isn't
+            # enforced this hangs forever.
+            response = await asyncio.wait_for(
+                reader.read(), timeout=2.0)
+            self.assertEqual(response, b"")
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+
 class AdminServerIntegrationTest(unittest.TestCase):
     """Boot the admin listener on an ephemeral port, hit /stats
     and /missing, confirm the responses."""
@@ -105,6 +140,8 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTests(loader.loadTestsFromTestCase(AdminStatsTest))
     suite.addTests(loader.loadTestsFromTestCase(RenderResponseTest))
+    suite.addTests(
+        loader.loadTestsFromTestCase(AdminSlowlorisTest))
     suite.addTests(
         loader.loadTestsFromTestCase(AdminServerIntegrationTest))
     return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pre-production review finding: the admin endpoint's `await reader.readline()` was unbounded. A peer that opened TCP and never sent `\r\n` would park a handler task forever (slowloris-style). Even bound to `127.0.0.1`, anyone on the host (or any compromised local service) could exhaust handler tasks.

Two blind `except Exception:` blocks also violated the project rule against bare catches and would hide cancellation-time errors.

## Current behavior before PR

```python
try:
    request_line = await reader.readline()    # unbounded
except Exception:                              # blind catch
    writer.close()
    return
```

## Desired behavior after PR is merged

- `asyncio.wait_for(reader.readuntil(b"\n"), timeout=ADMIN_REQUEST_TIMEOUT)` — 5 second cap on the request line.
- `ADMIN_REQUEST_LINE_LIMIT = 2048` passed to `asyncio.start_server(limit=...)` and enforced explicitly post-read.
- Both `except Exception:` blocks narrowed to specific tuples that match the realistic failure modes (`TimeoutError`, `IncompleteReadError`, `LimitOverrunError`, `ConnectionError`, `BrokenPipeError`); reasons are logged at DEBUG.

## Tests

- New `AdminSlowlorisTest.test_silent_peer_dropped_within_timeout` boots the listener with a 250 ms timeout, opens a silent connection, asserts the handler closes within 2 seconds.
- Existing 8 tests still pass.