### PR TITLE
senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
+- senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/src/senaite/astm/cli/astm_server.py
+++ b/src/senaite/astm/cli/astm_server.py
@@ -174,9 +174,21 @@ def main():
     args = parser.parse_args()
 
     _runtime.configure_logging(args)
-    _runtime.validate_output(args.output)
     if args.capture_only and not args.output:
         parser.error("--capture-only requires --output")
+    if args.capture_only and args.url:
+        # The modes are conceptually mutually exclusive: capture-
+        # only persists captures and stops there, --url tells the
+        # pipeline where to forward them. Letting them coexist
+        # silently means a misconfigured systemd unit (e.g. left
+        # --url in the line after adding --capture-only) ships
+        # with both flags and the operator never notices results
+        # aren't reaching the LIMS until somebody investigates.
+        parser.error(
+            "--capture-only is mutually exclusive with --url; "
+            "either drop --url to confirm capture-only, or drop "
+            "--capture-only to forward to the LIMS.")
+    _runtime.validate_output(args.output)
     if args.capture_only:
         logger.info(
             "Capture-only mode: LIMS push disabled; "

--- a/src/senaite/astm/tests/test_server_capture_only.py
+++ b/src/senaite/astm/tests/test_server_capture_only.py
@@ -6,8 +6,10 @@ accepts connections, writes captures to disk, and skips the LIMS
 push step even when --url is supplied.
 """
 
+import sys
 import unittest
 
+from senaite.astm.cli import astm_server
 from senaite.astm.cli.astm_server import build_arg_parser
 from senaite.astm.cli.astm_server import build_pipeline
 from senaite.astm.core.lims import LimsPushHandler
@@ -26,12 +28,14 @@ def _parse(extra):
 class BuildPipelineTest(unittest.TestCase):
 
     def test_capture_only_drops_lims_push(self):
+        # main() now rejects --capture-only + --url, so this test
+        # exercises build_pipeline with the post-validation shape
+        # (session=None, capture_only=True).
         args = _parse([
             "-o", "/tmp/out",
-            "-u", "http://admin:secret@localhost/senaite",
             "--capture-only",
         ])
-        pipeline = build_pipeline(args, _FakeSession())
+        pipeline = build_pipeline(args, None)
         kinds = [type(h) for h in pipeline.handlers]
         self.assertIn(DiskCaptureHandler, kinds)
         self.assertNotIn(LimsPushHandler, kinds)
@@ -57,9 +61,35 @@ class ParserTest(unittest.TestCase):
         self.assertTrue(args.capture_only)
 
 
+class CaptureOnlyConflictTest(unittest.TestCase):
+    """--capture-only + --url is a misconfiguration trap: the
+    operator probably forgot to drop one of them, and silently
+    ignoring --url would mean results never reach the LIMS without
+    a single warning. main() must reject the combination."""
+
+    def setUp(self):
+        self._saved_argv = sys.argv
+
+    def tearDown(self):
+        sys.argv = self._saved_argv
+
+    def test_main_rejects_capture_only_with_url(self):
+        sys.argv = [
+            "senaite-astm-server",
+            "-o", "/tmp/out",
+            "-u", "http://admin:secret@localhost/senaite",
+            "--capture-only",
+        ]
+        with self.assertRaises(SystemExit) as ctx:
+            astm_server.main()
+        # argparse parser.error -> exit code 2
+        self.assertEqual(ctx.exception.code, 2)
+
+
 def test_suite():
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
     suite.addTests(loader.loadTestsFromTestCase(BuildPipelineTest))
     suite.addTests(loader.loadTestsFromTestCase(ParserTest))
+    suite.addTests(loader.loadTestsFromTestCase(CaptureOnlyConflictTest))
     return suite

--- a/src/senaite/astm/tests/test_server_capture_only.py
+++ b/src/senaite/astm/tests/test_server_capture_only.py
@@ -69,9 +69,17 @@ class CaptureOnlyConflictTest(unittest.TestCase):
 
     def setUp(self):
         self._saved_argv = sys.argv
+        # `main()` calls `_runtime.configure_logging` which attaches
+        # handlers to the package logger; snapshot them so we can
+        # restore the original list in tearDown and avoid polluting
+        # later tests in the same process.
+        from senaite.astm import logger as pkg_logger
+        self._pkg_logger = pkg_logger
+        self._saved_handlers = list(pkg_logger.handlers)
 
     def tearDown(self):
         sys.argv = self._saved_argv
+        self._pkg_logger.handlers = self._saved_handlers
 
     def test_main_rejects_capture_only_with_url(self):
         sys.argv = [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pre-production review finding: when `--capture-only` was set, `args.session` was set to `None` and `--url` was silently ignored. A systemd unit that shipped with both flags (e.g. operator added `--capture-only` and forgot to drop the `--url` line) would persist captures without forwarding them to the LIMS, with zero signal in the log until somebody investigates why results aren't arriving.

## Current behavior before PR

```
senaite-astm-server -p 4010 -o ./hold -u http://...  --capture-only
# starts, persists captures, never pushes — operator doesn't know
```

## Desired behavior after PR is merged

```
senaite-astm-server -p 4010 -o ./hold -u http://... --capture-only
error: --capture-only is mutually exclusive with --url; either drop
--url to confirm capture-only, or drop --capture-only to forward to
the LIMS.
# exit code 2
```

The two modes are conceptually mutually exclusive. The error message names both flags so the operator knows which one to drop.

## Tests

- `CaptureOnlyConflictTest.test_main_rejects_capture_only_with_url` invokes `main()` with both flags and asserts `SystemExit(2)`.
- Existing 5 tests still pass.