### PR TITLE
senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
 - #65 senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
-- senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts
+- #68 senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
 - #65 senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
+- senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/src/senaite/astm/cli/astm_server.py
+++ b/src/senaite/astm/cli/astm_server.py
@@ -97,15 +97,26 @@ def build_pipeline(args, session):
     return Pipeline(handlers)
 
 
-def make_frame_callback(loop, pipeline, task_set):
+def make_frame_callback(loop, pipeline, task_set, stats=None):
     """ASTM-specific frame callback.
 
     The ASTM transport hands us a *list of frames* per session; we
     wrap them into an :class:`Envelope` before running the pipeline.
+    When `stats` is supplied the wrapper bumps `frames_in()` for
+    every batch the transport delivers, so the admin /stats
+    endpoint reports a live dispatch counter.
     """
-    return _runtime.make_frame_callback(
+    inner = _runtime.make_frame_callback(
         loop, pipeline, task_set,
         to_envelope=lambda frames: Wrapper(frames).to_envelope())
+    if stats is None:
+        return inner
+
+    def _wrapped(client, frames):
+        stats.frames_in()
+        return inner(client, frames)
+
+    return _wrapped
 
 
 async def amain(args, stop_event=None):
@@ -121,10 +132,14 @@ async def amain(args, stop_event=None):
     loop = asyncio.get_running_loop()
     task_set = set()
     pipeline = build_pipeline(args, args.session)
-    frame_callback = make_frame_callback(loop, pipeline, task_set)
+
+    stats = AdminStats() if getattr(args, "admin_port", None) else None
+    frame_callback = make_frame_callback(
+        loop, pipeline, task_set, stats=stats)
 
     server = await loop.create_server(
-        lambda: ASTMProtocol(frame_callback=frame_callback),
+        lambda: ASTMProtocol(
+            frame_callback=frame_callback, stats=stats),
         host=args.listen, port=args.port)
 
     for socket in server.sockets:
@@ -133,11 +148,7 @@ async def amain(args, stop_event=None):
     logger.info("ASTM server ready to handle connections ...")
 
     admin_server = None
-    if getattr(args, "admin_port", None):
-        stats = AdminStats()
-        # When stats hooks are wired into the protocol /
-        # pipeline, this is where the wrapping happens. The
-        # current minimum is to surface uptime + last_dispatch.
+    if stats is not None:
         admin_server = await start_admin_server(
             args.admin_listen, args.admin_port, stats)
 

--- a/src/senaite/astm/tests/test_adminstats_wiring.py
+++ b/src/senaite/astm/tests/test_adminstats_wiring.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""Tests for the wiring between ASTMProtocol / the frame-callback
+and the AdminStats counter bag exposed at /stats.
+
+Pre-production review flagged that AdminStats() was instantiated
+but never updated, so /stats perpetually reported zeros. These
+tests guard the wiring: a session opening and closing must bump
+the counters; a frame batch handed to the wrapped frame_callback
+must increment frames_dispatched.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from senaite.astm.admin import AdminStats
+from senaite.astm.cli.astm_server import make_frame_callback
+from senaite.astm.transports.astm.protocol import ASTMProtocol
+
+
+class ProtocolSessionWiringTest(unittest.TestCase):
+
+    def _fake_transport(self, peer=("1.2.3.4", 9999)):
+        transport = MagicMock()
+        transport.get_extra_info.return_value = peer
+        return transport
+
+    def test_connection_made_bumps_active_sessions(self):
+        stats = AdminStats()
+        proto = ASTMProtocol(stats=stats)
+        asyncio.run(self._made(proto))
+        self.assertEqual(
+            stats.snapshot()["active_sessions"], 1)
+
+    async def _made(self, proto):
+        proto.connection_made(self._fake_transport())
+
+    def test_connection_lost_balances_session_count(self):
+        stats = AdminStats()
+        proto = ASTMProtocol(stats=stats)
+        asyncio.run(self._made_then_lost(proto))
+        self.assertEqual(
+            stats.snapshot()["active_sessions"], 0)
+
+    async def _made_then_lost(self, proto):
+        proto.connection_made(self._fake_transport())
+        proto.connection_lost(None)
+
+    def test_no_stats_is_a_no_op(self):
+        proto = ASTMProtocol()
+        # connection_made / connection_lost must not raise when
+        # stats is None — older callers don't pass it.
+        asyncio.run(self._made_then_lost(proto))
+
+
+class FrameCallbackWiringTest(unittest.TestCase):
+
+    def test_wrapped_callback_increments_frames_dispatched(self):
+        loop = asyncio.new_event_loop()
+        try:
+            stats = AdminStats()
+            pipeline = MagicMock()
+            pipeline.run = MagicMock()
+            task_set = set()
+
+            cb = make_frame_callback(
+                loop, pipeline, task_set, stats=stats)
+            # The wrapped callback is sync — calling it must bump
+            # frames_in. We don't care that the inner callback
+            # schedules a task; only that the counter ticked.
+            cb("client-1", [b"\x021H|\\^&|\x03B7"])
+
+            self.assertEqual(
+                stats.snapshot()["frames_dispatched"], 1)
+            self.assertIsNotNone(
+                stats.snapshot()["last_dispatch_at"])
+        finally:
+            loop.close()
+
+    def test_no_stats_returns_inner_callback_unwrapped(self):
+        loop = asyncio.new_event_loop()
+        try:
+            pipeline = MagicMock()
+            task_set = set()
+            cb = make_frame_callback(
+                loop, pipeline, task_set, stats=None)
+            # No exception means the unwrapped path works.
+            cb("client-1", [b"\x021H|\\^&|\x03B7"])
+        finally:
+            loop.close()
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(
+        loader.loadTestsFromTestCase(ProtocolSessionWiringTest))
+    suite.addTests(
+        loader.loadTestsFromTestCase(FrameCallbackWiringTest))
+    return suite

--- a/src/senaite/astm/transports/astm/protocol.py
+++ b/src/senaite/astm/transports/astm/protocol.py
@@ -38,10 +38,20 @@ class ASTMProtocol(asyncio.Protocol):
     bytes in arrival order.
     """
 
-    def __init__(self, frame_callback=None, timeout=TIMEOUT):
+    def __init__(self, frame_callback=None, timeout=TIMEOUT,
+                 stats=None):
+        """
+        :param stats: Optional :class:`senaite.astm.admin.AdminStats`
+            counter bag. When supplied, the protocol calls
+            `stats.session_opened()` on connect and
+            `stats.session_closed()` on disconnect. None is the
+            documented default — the protocol works standalone in
+            tests that don't care about admin metrics.
+        """
         logger.debug("ASTMProtocol:constructor")
         self.frame_callback = frame_callback
         self.timeout = timeout
+        self.stats = stats
 
         self.loop = None
         self.transport = None
@@ -69,6 +79,8 @@ class ASTMProtocol(asyncio.Protocol):
         self.transport = transport
         self.client = self.get_client_key(transport)
         logger.debug("Connection from {!s}".format(self.client))
+        if self.stats is not None:
+            self.stats.session_opened()
 
     def connection_lost(self, ex):
         # Distinguish "client closed without sending data" (typical
@@ -82,6 +94,8 @@ class ASTMProtocol(asyncio.Protocol):
         else:
             logger.warning(
                 "Lost connection for %s", self.client)
+        if self.stats is not None:
+            self.stats.session_closed()
         self.close_connection()
 
     def _session_was_empty(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pre-production review finding: `--admin-port` shipped with an `AdminStats()` instance that was created and read by the `/stats` endpoint but never updated. The endpoint perpetually returned `active_sessions=0, frames_dispatched=0` — a monitoring endpoint that lies is worse than no monitoring endpoint.

## Current behavior before PR

`cli/astm_server.py` contained a TODO comment:

```python
# When stats hooks are wired into the protocol /
# pipeline, this is where the wrapping happens. The
# current minimum is to surface uptime + last_dispatch.
```

`/stats` always returned zeros for `active_sessions` and `frames_dispatched`.

## Desired behavior after PR is merged

- `ASTMProtocol` gains a `stats=` kwarg.
- `connection_made` calls `stats.session_opened()`; `connection_lost` calls `stats.session_closed()`.
- `make_frame_callback` wraps the inner callback when `stats` is supplied so every batch the transport delivers bumps `frames_in()` before the pipeline task is scheduled.
- `amain` creates one `AdminStats` only when `--admin-port` is set and threads it through both call sites.

## Tests

- `ProtocolSessionWiringTest`: `connection_made` increments `active_sessions`; `connection_lost` balances it back; `stats=None` is a no-op.
- `FrameCallbackWiringTest`: the wrapped callback bumps `frames_dispatched` and sets `last_dispatch_at`; the unwrapped path still works.
- Existing protocol + admin tests still pass (18 in the touched test files).