### PR TITLE
core: bundled should-fix items — idempotent log handlers, sys.exit(1) on validate failure, --validate-only exit code capped, narrower transport / inspect except logging

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
 - #65 senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
 - #68 senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts
+- core: bundled should-fix items — idempotent log handlers, sys.exit(1) on validate failure, --validate-only exit code capped, narrower transport / inspect except logging
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Changelog
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
 - #65 senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
 - #68 senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts
-- core: bundled should-fix items — idempotent log handlers, sys.exit(1) on validate failure, --validate-only exit code capped, narrower transport / inspect except logging
+- #69 core: bundled should-fix items — idempotent log handlers, sys.exit(1) on validate failure, --validate-only exit code capped, narrower transport / inspect except logging
 - senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
 - senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
 - senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file

--- a/src/senaite/astm/cli/_runtime.py
+++ b/src/senaite/astm/cli/_runtime.py
@@ -33,26 +33,46 @@ DEFAULT_SHUTDOWN_GRACE_SECONDS = 30
 
 def configure_logging(args):
     """Attach the rotating logfile + stream handlers to the package
-    logger and set the verbosity from ``args.verbose``."""
+    logger and set the verbosity from ``args.verbose``.
+
+    Idempotent: a StreamHandler is added only if the logger has
+    none already, and the rotating file handler is added only when
+    no existing handler points at the same file. Without these
+    guards a test suite that invokes the CLI repeatedly piles up
+    duplicate handlers and prints every log line N times."""
     if getattr(args, "logfile", None):
-        handler = logging.handlers.RotatingFileHandler(
-            args.logfile,
-            maxBytes=LOGFILE_MAX_BYTES,
-            backupCount=LOGFILE_BACKUP_COUNT)
-        handler.setFormatter(logging.Formatter(
-            "%(asctime)s %(levelname)-8s %(message)s"))
-        logger.addHandler(handler)
+        already_pointed_at_file = any(
+            isinstance(h, logging.handlers.RotatingFileHandler)
+            and h.baseFilename == os.path.abspath(args.logfile)
+            for h in logger.handlers)
+        if not already_pointed_at_file:
+            handler = logging.handlers.RotatingFileHandler(
+                args.logfile,
+                maxBytes=LOGFILE_MAX_BYTES,
+                backupCount=LOGFILE_BACKUP_COUNT)
+            handler.setFormatter(logging.Formatter(
+                "%(asctime)s %(levelname)-8s %(message)s"))
+            logger.addHandler(handler)
 
     logger.setLevel(
         logging.DEBUG if getattr(args, "verbose", False) else logging.INFO)
-    logger.addHandler(logging.StreamHandler())
+    if not any(isinstance(h, logging.StreamHandler)
+               and not isinstance(h, logging.FileHandler)
+               for h in logger.handlers):
+        logger.addHandler(logging.StreamHandler())
 
 
 def validate_output(output):
-    """Exit with an error if ``output`` is set but not a directory."""
+    """Exit with an error if ``output`` is set but not a directory.
+
+    Uses ``sys.exit(1)`` rather than ``sys.exit(-1)``: on POSIX the
+    negative value is sign-flipped to 255 by the C runtime, which
+    some monitoring tools interpret as "killed by signal" rather
+    than "exited cleanly with an error".
+    """
     if output and not os.path.isdir(output):
         logger.error("Output path must be an existing directory")
-        sys.exit(-1)
+        sys.exit(1)
 
 
 def install_shutdown_handlers(loop, stop_event):
@@ -200,5 +220,5 @@ def validate_lims(url):
         session.auth()
     except lims.SenaiteError as exc:
         logger.error("Could not connect to SENAITE: {}".format(exc))
-        raise SystemExit(-1)
+        raise SystemExit(1)
     return session

--- a/src/senaite/astm/inspect.py
+++ b/src/senaite/astm/inspect.py
@@ -69,7 +69,12 @@ def cmd_instrument(args, stream):
         try:
             _env, frames = _read_envelope(path)
         except Exception as exc:
-            stream.write("%s: ERROR %s\n" % (path, exc))
+            # Inspection should report any failure mode rather
+            # than aborting the whole batch; logging the exception
+            # type lets the operator distinguish "file not found"
+            # from "checksum mismatch" from "decoder asserted".
+            stream.write("%s: ERROR %s: %s\n" % (
+                path, type(exc).__name__, exc))
             continue
         stream.write("%s: %s\n" % (path, _resolve_instrument(frames)))
     return 0
@@ -80,7 +85,12 @@ def cmd_summary(args, stream):
         try:
             env, frames = _read_envelope(path)
         except Exception as exc:
-            stream.write("%s: ERROR %s\n" % (path, exc))
+            # Inspection should report any failure mode rather
+            # than aborting the whole batch; logging the exception
+            # type lets the operator distinguish "file not found"
+            # from "checksum mismatch" from "decoder asserted".
+            stream.write("%s: ERROR %s: %s\n" % (
+                path, type(exc).__name__, exc))
             continue
         counts = _bucket_counts(env)
         parts = ["%s=%d" % (rt, counts[rt]) for rt in RECORD_TYPES]

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -354,13 +354,23 @@ def main():
 
     logger.setLevel(
         logging.DEBUG if args.verbose else logging.INFO)
-    logger.addHandler(logging.StreamHandler())
+    # Idempotent: avoid stacking duplicate StreamHandlers when the
+    # CLI is invoked repeatedly under one Python process (test
+    # suites, supervisord short-restart cycles).
+    if not any(isinstance(h, logging.StreamHandler)
+               and not isinstance(h, logging.FileHandler)
+               for h in logger.handlers):
+        logger.addHandler(logging.StreamHandler())
 
     if not args.infile:
         return
 
     if args.validate_only:
-        sys.exit(_validate_only(args.infile, args.rebuild_checksums))
+        failures = _validate_only(args.infile, args.rebuild_checksums)
+        # Cap exit code at 1 so it never overflows the 8-bit POSIX
+        # exit-code range. 300 failed fixtures would otherwise wrap
+        # to 44 and a CI step might mis-classify that as success.
+        sys.exit(1 if failures else 0)
 
     if args.scrub_phi and args.message_format != "json":
         logger.error(

--- a/src/senaite/astm/tests/test_inspect.py
+++ b/src/senaite/astm/tests/test_inspect.py
@@ -38,6 +38,9 @@ class InstrumentTest(unittest.TestCase):
         rc, out = _run(["instrument", "/no/such/file.astm"])
         self.assertEqual(rc, 0)
         self.assertIn("ERROR", out)
+        # The error line names the exception type so operators
+        # can distinguish file/parse/checksum failure modes.
+        self.assertIn("FileNotFoundError", out)
 
 
 class SummaryTest(unittest.TestCase):

--- a/src/senaite/astm/transports/astm/protocol.py
+++ b/src/senaite/astm/transports/astm/protocol.py
@@ -265,7 +265,15 @@ class ASTMProtocol(asyncio.Protocol):
             logger.debug("No frame_callback registered; dropping %d frames",
                          len(frames))
             return
+        # Bare-Exception catch on purpose: the frame_callback is
+        # caller-supplied, so any error there must not propagate
+        # up to the asyncio Protocol layer and tear the transport
+        # down for unrelated future sessions. We log type + repr
+        # so the operator can tell apart a programming error from
+        # a downstream LIMS / disk error.
         try:
             self.frame_callback(self.client, frames)
         except Exception as exc:
-            logger.error("frame_callback raised %r; frames dropped", exc)
+            logger.error(
+                "frame_callback raised %s: %r; frames dropped",
+                type(exc).__name__, exc)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Six independent should-fix items from the pre-production review, bundled per the operator's request (one PR per blocker, one PR for the lower-priority items):

| # | Item |
|---|---|
| 6 | Duplicate `StreamHandler` on the logger across repeated invocations |
| 8 | (re-auth) — kept separate, not in this bundle |
| 11 | `sys.exit(-1)` becomes 255 on POSIX |
| 12 | `--validate-only` exit code can overflow on 256+ failures |
| 14 | Frame-callback blind `except` should log exception type |
| 15 | `senaite-astm-inspect` ERROR lines should name the exception type |

## Current behavior before PR

- `configure_logging` and `sender.main` both unconditionally call `logger.addHandler(StreamHandler())` — duplicate handlers on repeated invocations.
- `validate_output` and `validate_lims` use `sys.exit(-1)` / `SystemExit(-1)`; POSIX sign-flips to 255.
- `--validate-only` does `sys.exit(failure_count)` — 300 broken fixtures exits 0.
- `dispatch_frames` logs only `repr(exc)`; operator cannot tell a `TypeError` from a `RequestException`.
- `senaite-astm-inspect` ERROR lines are `<path>: ERROR <message>` — type lost.

## Desired behavior after PR is merged

- `configure_logging` is idempotent (Stream + Rotating).
- `sender.main` guards its `StreamHandler` add the same way.
- Exit codes use `1` not `-1`.
- `--validate-only` exits `1 if failures else 0`.
- Frame-callback log lines include the exception type name.
- Inspect ERROR lines include the exception type name (now `<path>: ERROR FileNotFoundError: ...`).

## Tests

- All 446 existing tests still pass (1 pre-existing skip).
- `test_inspect.test_handles_missing_file_gracefully` updated to assert the exception-type token appears on the error line.

## Out of scope (deferred)

- Item 8 (re-auth on 401) — needs design for how to detect cookie expiry, deferred.
- Item 7 (feed Pipeline results into AdminStats / dead_letter) — needs a follow-up on the dead-letter contract.
- Item 9 (`_apply_substitutions` safety guards) — deferred until we see real misuse.