### PR TITLE
Move changelog to repo-root CHANGES.rst (senaite.core style), prefix backfilled PR numbers on 2.x entries, add quickstart / CLI / deployment docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,19 +11,19 @@ Changelog
 - #65 senaite-astm-send: switch --scrub-phi to a redact-by-allowlist policy so unknown P-record fields no longer leak
 - #68 senaite-astm-server: wire AdminStats into ASTMProtocol and the frame callback so /stats reports real session and dispatch counts
 - #69 core: bundled should-fix items — idempotent log handlers, sys.exit(1) on validate failure, --validate-only exit code capped, narrower transport / inspect except logging
-- senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
-- senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
-- senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file
-- senaite-astm-server: add --admin-port for a read-only HTTP /stats endpoint (uptime, sessions, dispatches)
-- senaite-astm-send: add --validate-only to parse + envelope-check captures without pushing to a LIMS
-- senaite-astm-send: add --scrub-phi to redact patient identifiers in the JSON envelope before pushing
-- senaite-astm-inspect: new read-only CLI for instrument / summary / diff over captured ASTM files
-- senaite-astm-server: add --capture-only to persist captures without forwarding them to the LIMS
-- senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
-- senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
-- senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS
-- Decode Yumizen HISTOGRAM and MATRIX encoded streams into float lists in the envelope
-- Quiet empty-session disconnects: log TCP-probe drops at DEBUG, keep WARNING for mid-session cuts
+- #63 senaite-astm-server: add --capture-only to persist captures without forwarding them to the LIMS
+- #62 senaite-astm-server: add --admin-port for a read-only HTTP /stats endpoint (uptime, sessions, dispatches)
+- #60 senaite-astm-inspect: new read-only CLI for instrument / summary / diff over captured ASTM files
+- #59 senaite-astm-send: add --dry-run to log the planned request (URL, consumer, sizes) without contacting the LIMS
+- #58 senaite-astm-send: add --filter-records / --drop-records to trim envelope buckets before serialisation
+- #57 senaite-astm-send: add --scrub-phi to redact patient identifiers in the JSON envelope before pushing
+- #56 senaite-astm-send: add --validate-only to parse + envelope-check captures without pushing to a LIMS
+- #55 senaite-astm-send: add --substitute-sample-id OLD=NEW for retargeting a captured fixture without editing the file
+- #54 senaite-astm-send: add -o / --output to convert captures to disk or stdout instead of pushing to a LIMS
+- #53 senaite-astm-send: add --rebuild-checksums to repair hand-edited captures before parsing
+- #52 senaite-astm-send: add -m / --message-format (json / astm / lis2a) for replaying captures into a LIMS
+- #51 Decode Yumizen HISTOGRAM and MATRIX encoded streams into float lists in the envelope
+- #50 Quiet empty-session disconnects: log TCP-probe drops at DEBUG, keep WARNING for mid-session cuts
 - #49 Lift validate_lims, frame_callback dispatch, and LIMS arg group into _runtime
 - #48 Synthetic ASTM adapters: extract framing dance into synthesize_session helper
 - #47 HL7 parser: preserve unmapped segments under metadata.unmapped_segments

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# senaite.astm documentation
+
+ASTM and HL7-over-MLLP transport for laboratory instruments,
+wired to a SENAITE LIMS via the SENAITE push consumer interface.
+
+senaite.astm ships three CLIs:
+
+- **`senaite-astm-server`** — long-running TCP listener that
+  accepts ASTM (or HL7) sessions from instruments and forwards
+  them to the LIMS.
+- **`senaite-astm-send`** — one-shot CLI that replays a captured
+  ASTM file into a LIMS without bringing up a listener. Also
+  used for offline conversion, validation and PHI scrubbing.
+- **`senaite-astm-inspect`** — read-only introspection of
+  captured ASTM files (instrument resolution, summary,
+  structural diff).
+
+## Contents
+
+- [Quickstart](quickstart.md) — install, boot, replay, validate.
+- [CLI reference](cli.md) — every flag on every command.
+- [Deployment](deployment.md) — systemd / supervisord units,
+  admin endpoint, PHI scrubbing, recovery workflows.
+- [Changelog](../CHANGES.rst) — release notes (at the repo root).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,167 @@
+# CLI reference
+
+senaite.astm ships three console scripts. Every flag is
+documented inline with `--help`; this page collects the same
+information in a single browsable reference.
+
+## senaite-astm-server
+
+Long-running TCP listener that accepts ASTM sessions, persists
+captures, and forwards parsed envelopes to a SENAITE LIMS.
+
+### Listener
+
+- `-l, --listen IP` — bind address. Defaults to `0.0.0.0`.
+- `-p, --port PORT` — TCP port. Defaults to `4010`.
+- `-o, --output DIR` — directory where every captured session
+  is written as a timestamped file. Required for
+  `--capture-only`; otherwise optional but strongly recommended
+  in production so that replay / audit is possible after a LIMS
+  outage.
+- `--shutdown-grace-seconds N` — seconds to wait for in-flight
+  pipeline tasks to finish before cancelling them on SIGTERM.
+  Defaults to `30`.
+
+### Operating modes
+
+- `--capture-only` — accept connections and persist captures,
+  but skip the LIMS push step. Useful for a hold-and-review
+  workflow when commissioning a new instrument. Requires
+  `--output`; mutually exclusive with `--url`.
+
+### Admin endpoint
+
+- `--admin-port PORT` — open a read-only HTTP admin endpoint.
+  `GET /stats` returns JSON: `uptime_seconds`,
+  `active_sessions`, `frames_dispatched`, `last_dispatch_at`.
+  Off by default.
+- `--admin-listen IP` — bind address for `--admin-port`.
+  Defaults to `127.0.0.1` because the endpoint is
+  unauthenticated.
+
+### LIMS push
+
+- `-u, --url URL` — SENAITE URL with credentials:
+  `http(s)://user:password@host[:port]/path`.
+- `-c, --consumer NAME` — SENAITE push consumer interface.
+  Defaults to `senaite.core.lis2a.import`.
+- `-m, --message-format {json,astm,lis2a}` — format of the
+  message body POSTed to SENAITE. `json` is the parsed typed
+  envelope (what current SENAITE consumers expect). `astm` and
+  `lis2a` are raw / flat-text variants for legacy consumers.
+- `-r, --retries N` — push attempts on transient failures.
+  Defaults to `3`.
+- `-d, --delay SEC` — seconds between push retries. Defaults
+  to `5`.
+
+### Diagnostics
+
+- `-v, --verbose` — DEBUG-level logging.
+- `--logfile PATH` — rotating log file. Defaults to
+  `senaite-astm-server.log` in the working directory.
+
+## senaite-astm-send
+
+One-shot CLI that replays a captured ASTM file. Composes
+substitution, validation, scrubbing, filtering and dry-run
+into a single processing pipeline.
+
+### Inputs
+
+- `-i, --infile FILE [FILE ...]` — one or more captured ASTM
+  files. Read in order, each producing one message.
+
+### Pre-parse transformations
+
+- `--substitute-sample-id OLD=NEW` — replace every occurrence
+  of OLD with NEW in the raw capture before parsing.
+  Repeatable. Primary use: retarget a captured file to a
+  different sample id without editing it. The substitution
+  invalidates the affected frame's 2-byte checksum, so combine
+  with `--rebuild-checksums`.
+- `--rebuild-checksums` — recompute the trailing checksum of
+  every ASTM frame before parsing. Use after any byte-level
+  edit (substitution, scrub). Off by default so genuine wire
+  corruption is not silently masked.
+
+### Envelope transformations
+
+- `--scrub-phi` — redact every P-record field that is not in
+  the non-PHI allowlist (`type`, `seq`, `sex`, `race`,
+  `height`, `weight`, `diet`, `reserved`) with `<REDACTED>`.
+  Also clears `metadata.astm` and `metadata.lis2a` so the
+  verbatim flat-text payloads do not leak through. Requires
+  `--message-format json` (raw and flat outputs cannot be
+  rewritten safely).
+- `--scrub-phi-keep-field KEY` — extend the non-PHI allowlist
+  with a vendor-specific non-identifying field. Repeatable.
+- `--filter-records TYPES` — keep only the listed record-type
+  buckets in the parsed envelope (`H,P,O,R,C,M,L,Q`). Mutually
+  exclusive with `--drop-records`. Requires
+  `--message-format json`.
+- `--drop-records TYPES` — drop the listed record-type buckets
+  from the parsed envelope.
+
+### Output modes
+
+- `-o, --output PATH` — write the converted message(s) instead
+  of pushing to a LIMS.
+  - `-` — write to stdout. Single input only.
+  - existing directory — write one file per input as
+    `<input-stem>.<ext>`.
+  - regular file path — single input only.
+
+  When set, `--url` is not required.
+- `--dry-run` — log the URL, consumer, message count and
+  per-message format + byte size that would be pushed to the
+  LIMS, then exit without opening a connection. The URL
+  password is masked.
+- `--validate-only` — parse each input file into the typed
+  envelope and report success or failure per file. No LIMS
+  push, no output. Exit code is `1` on any failure, `0`
+  otherwise.
+
+### Format / LIMS
+
+- `-m, --message-format {json,astm,lis2a}` — see
+  `senaite-astm-server` above. Defaults to `json`.
+- `-u, --url URL` — SENAITE URL with credentials. Required
+  unless `--output`, `--dry-run` or `--validate-only` is set.
+- `-c, --consumer NAME` — push consumer interface.
+- `-r, --retries N` / `-d, --delay SEC` — push retry tuning.
+
+## senaite-astm-inspect
+
+Read-only introspection of captured ASTM files. No LIMS push,
+no writes — safe to run against production captures.
+
+### instrument
+
+```
+senaite-astm-inspect instrument FILE [FILE ...]
+```
+
+Prints the canonical instrument name resolved from each file's
+first frame, one line per file. `unknown` when no registered
+instrument matches the header.
+
+### summary
+
+```
+senaite-astm-inspect summary FILE [FILE ...]
+```
+
+One-line summary per file:
+
+```
+capture.txt: instrument=H500 sample_id=CLVB262207 H=1 P=1 O=1 R=20 C=2 M=4 L=1 Q=0
+```
+
+### diff
+
+```
+senaite-astm-inspect diff FILE_A FILE_B
+```
+
+Unified diff of the two parsed envelopes' JSON serialisation.
+Exit code is `1` when files differ, `0` when identical.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,200 @@
+# Deployment
+
+This page covers production operation of `senaite-astm-server`:
+process supervision, log rotation, the admin HTTP endpoint,
+PHI scrubbing, and the recovery workflow when the LIMS is down.
+
+## Process supervision
+
+### systemd
+
+```
+# /etc/systemd/system/senaite-astm-server.service
+[Unit]
+Description=SENAITE ASTM Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=senaite
+Group=senaite
+WorkingDirectory=/opt/senaite-astm
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/senaite-astm/.venv/bin/senaite-astm-server \
+    -p 4010 \
+    -o /var/lib/senaite-astm/captures \
+    -u https://admin:%i@senaite.lab.invalid \
+    --admin-port 4011 \
+    --logfile /var/log/senaite-astm/server.log
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Notes:
+
+- `Restart=on-failure` recovers from any non-zero exit. The
+  code uses `sys.exit(1)` consistently (no negative codes that
+  POSIX sign-flips to 255).
+- `Type=simple` is correct — the server does not daemonise on
+  its own.
+- Keep the URL out of the unit file when possible (e.g. use
+  `LoadCredential=` or read from a secrets file at startup).
+
+### supervisord
+
+```
+[program:senaite-astm-server]
+command=/opt/senaite-astm/.venv/bin/senaite-astm-server
+        -p 4010
+        -o /var/lib/senaite-astm/captures
+        -u https://admin:secret@senaite.lab.invalid
+        --admin-port 4011
+        --logfile /var/log/senaite-astm/server.log
+autostart=true
+autorestart=true
+startsecs=5
+user=senaite
+redirect_stderr=true
+stdout_logfile=/var/log/senaite-astm/supervisor.log
+```
+
+## Admin endpoint
+
+`--admin-port N` opens a tiny HTTP server (asyncio, hand-rolled
+HTTP/1.1, no external deps) that answers `GET /stats` with a
+JSON snapshot:
+
+```
+curl http://127.0.0.1:4011/stats
+{
+  "uptime_seconds": 12345.6,
+  "active_sessions": 0,
+  "frames_dispatched": 42,
+  "last_dispatch_at": 1717336800.123
+}
+```
+
+Counters:
+
+- `active_sessions` — instrument connections currently open.
+- `frames_dispatched` — per-session frame batches handed to the
+  pipeline since process start.
+- `last_dispatch_at` — Unix timestamp of the most recent
+  dispatch, or `null` when no message has been received yet.
+
+Safety:
+
+- Bind defaults to `127.0.0.1` because the endpoint is
+  **unauthenticated**.
+- `--admin-listen` overrides the bind if the operator
+  genuinely needs a non-loopback interface (e.g. a private
+  monitoring VLAN).
+- Request lines are capped at 2 KiB and read within 5 s to
+  prevent slowloris-style resource exhaustion.
+
+### Health checks
+
+A scraper that wants "is the process alive" should poll
+`/stats` and assert `uptime_seconds` increases between calls.
+A scraper that wants "are messages still flowing" should alert
+when `last_dispatch_at` is older than the expected
+inter-message gap for the deployed instruments.
+
+## Capture directory and replay
+
+Every accepted session is persisted to the `--output` directory
+as `<microsecond-timestamp>.txt`. The filename has microsecond
+resolution so two instruments hitting the server within the
+same second do not silently overwrite each other.
+
+The capture file is the durable source of truth. If the LIMS
+push fails after retries, the capture is still on disk and the
+operator can replay it later:
+
+```
+senaite-astm-send \
+    -i /var/lib/senaite-astm/captures/<file>.txt \
+    -u https://admin:secret@senaite.lab.invalid
+```
+
+For a recurring "send everything that hasn't been pushed yet"
+workflow, pair the capture handler with a sidecar `.ok` marker
+file written by your own post-push hook, and a shell loop that
+walks the directory for `*.txt` without a matching `*.ok`.
+
+## Log rotation
+
+`--logfile` enables a rotating file handler with sensible
+defaults (10 MiB max, 5 backups). The default formatter is
+`%(asctime)s %(levelname)-8s %(message)s`.
+
+Repeated invocations of `configure_logging` are idempotent —
+no duplicate handlers stack up if the CLI is re-invoked under
+the same Python process (matters for test runners and
+short-restart supervisors).
+
+## PHI scrubbing
+
+`--scrub-phi` is the privacy guarantee for replays into
+non-production LIMSes. The allowlist of P-record fields kept
+unredacted is:
+
+- `type`, `seq` — record metadata
+- `sex`, `race` — demographics (typically retained for clinical
+  context)
+- `height`, `weight`, `diet` — clinical observations
+- `reserved` — ASTM placeholder, never populated
+
+Every other P-record field is replaced with `<REDACTED>`.
+`metadata.astm` and `metadata.lis2a` are also cleared so the
+verbatim flat-text payloads do not leak.
+
+Add vendor-specific non-identifying fields to the allowlist
+with `--scrub-phi-keep-field KEY` (repeatable). Never widen
+the allowlist to include obvious PHI fields like `name`,
+`birthdate`, `address` or the various ID fields.
+
+## LIMS timeout and retries
+
+The LIMS HTTP push has a default timeout of
+`(connect=10s, read=60s)`. A hung Zope worker is recycled
+within a minute rather than pinning an asyncio thread-pool
+worker indefinitely.
+
+Retry tuning:
+
+- `-r, --retries 3` (default) — three push attempts on
+  transient failures.
+- `-d, --delay 5` (default) — seconds between retries.
+
+A 401 / 403 response is **not** retried — the operator likely
+needs to fix credentials.
+
+## Shutdown behaviour
+
+On SIGINT / SIGTERM the server stops accepting new connections
+and waits up to `--shutdown-grace-seconds N` (default 30) for
+in-flight pipeline tasks to finish before cancelling them. The
+log records both the count and the grace period so the operator
+can tune to the deployment's largest expected message size.
+
+## Capture-only mode
+
+```
+senaite-astm-server -p 4010 -o ./hold --capture-only
+```
+
+Useful when:
+
+- Commissioning a new instrument — confirm the wire shape
+  before involving the LIMS.
+- Wiring up a new consumer adapter — collect a few real
+  captures, then replay them through `senaite-astm-send`.
+
+`--url` is rejected in this mode so a misconfigured systemd
+unit fails loudly rather than silently dropping every captured
+message.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,108 @@
+# Quickstart
+
+This walkthrough takes you from a fresh checkout to a running
+`senaite-astm-server` that captures live ASTM traffic and
+forwards it to a SENAITE LIMS, plus a one-shot replay of a
+captured fixture via `senaite-astm-send`.
+
+## Install
+
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Three console scripts are registered:
+
+- `senaite-astm-server` (long-running listener)
+- `senaite-astm-send` (one-shot replay / convert / validate)
+- `senaite-astm-inspect` (read-only introspection)
+
+## Boot the server against a SENAITE LIMS
+
+```
+senaite-astm-server \
+    -p 4010 \
+    -o ./captures \
+    -u http://admin:secret@localhost:8080/senaite \
+    --logfile ./var/log/senaite-astm-server.log
+```
+
+What this does:
+
+- Listens for ASTM TCP sessions on port `4010`.
+- Persists every captured session to `./captures/` as a
+  timestamped file.
+- Forwards every parsed envelope to the SENAITE consumer
+  `senaite.core.lis2a.import`.
+- Writes a rotating log file to `./var/log/`.
+
+## Boot the server in capture-only mode
+
+When commissioning a new instrument or wiring up a new
+consumer adapter, run the server in hold-and-review mode:
+
+```
+senaite-astm-server -p 4010 -o ./hold --capture-only
+```
+
+`--capture-only` accepts connections, persists captures, and
+skips the LIMS push step. `--url` is rejected in this mode —
+the operator picks one mode or the other.
+
+## Replay a captured file
+
+The simplest replay form sends the captured bytes as a typed
+JSON envelope through the SENAITE push endpoint:
+
+```
+senaite-astm-send \
+    -i ./captures/2026-06-02_14_23_01.456.txt \
+    -m json \
+    -u http://admin:secret@localhost:8080/senaite
+```
+
+## Re-target the sample id without editing the file
+
+When the captured file references a sample id that no longer
+exists in the LIMS, swap it on the fly. The substitution
+invalidates the affected frame's 2-byte checksum, so combine
+with `--rebuild-checksums`:
+
+```
+senaite-astm-send \
+    -i ./captures/original.txt \
+    --substitute-sample-id OLD_ID=NEW_ID \
+    --rebuild-checksums \
+    -u http://admin:secret@localhost:8080/senaite
+```
+
+## Inspect a captured file
+
+```
+senaite-astm-inspect instrument captures/*.txt
+senaite-astm-inspect summary    captures/*.txt
+senaite-astm-inspect diff       a.txt b.txt
+```
+
+No LIMS contact, no writes — safe to run against production
+captures.
+
+## Validate captures in CI
+
+`--validate-only` parses each input into the typed envelope
+and reports per-file pass / fail. Exit code is `1` when any
+file fails, `0` otherwise — drop-in for a CI step:
+
+```
+senaite-astm-send --validate-only -i tests/fixtures/*.txt
+```
+
+## Where to go next
+
+- [CLI reference](cli.md) — full reference for every flag on
+  every command.
+- [Deployment](deployment.md) — production deployment notes
+  (supervisord / systemd, the `--admin-port` HTTP stats
+  endpoint, log rotation, PHI scrubbing).


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Three docs hygiene tasks bundled per the operator's request:

1. Backfill `#N` prefixes on the 2.x changelog entries that pre-dated the prefix convention (PRs #50–#63).
2. Move `docs/changelog.rst` to a top-level `CHANGES.rst` so the layout matches senaite.core.
3. Seed a real `docs/` tree (quickstart, CLI reference, deployment) in markdown.

## Layout after this PR

- `CHANGES.rst` — master changelog at repo root (senaite.core style).
- `docs/README.md` — landing page.
- `docs/quickstart.md` — install, boot, replay, inspect, validate-only.
- `docs/cli.md` — complete reference across all three console scripts (every flag documented).
- `docs/deployment.md` — systemd / supervisord units, `--admin-port` HTTP `/stats`, PHI scrubbing policy, LIMS timeout / retries, capture-only mode, shutdown grace.

The previous `docs/changelog.rst` is removed (no include indirection needed once the rest of the docs are markdown).

## Tests

Docs-only PR — no code changes, no test impact.