### PR TITLE
core: include CHANGES.md in setup.py long_description and add MANIFEST.in so the changelog ships in the sdist and renders on PyPI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,8 @@
-Changelog
-=========
+# Changelog
 
+## 2.0.0
 
-2.0.0
------
-
+- core: include CHANGES.md in setup.py long_description and add MANIFEST.in so the changelog ships in the sdist and renders on PyPI
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers
 - #67 senaite-astm-server: reject --capture-only combined with --url so a misconfigured systemd unit fails loudly
@@ -46,9 +44,7 @@ Changelog
 - #27 Lift LIMS push into core/ with typed errors and PushResult
 - #26 Drop Python 2 compatibility shims
 
-
-1.0.0
------
+## 1.0.0
 
 - #25 Add test scaffold for the ASTM pipeline
 - #23 Add Cepheid GeneXpert import schema

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include CHANGES.md
+include LICENSE
+recursive-include docs *.md
+recursive-include src *.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,4 @@ senaite.astm ships three CLIs:
 - [CLI reference](cli.md) — every flag on every command.
 - [Deployment](deployment.md) — systemd / supervisord units,
   admin endpoint, PHI scrubbing, recovery workflows.
-- [Changelog](../CHANGES.rst) — release notes (at the repo root).
+- [Changelog](../CHANGES.md) — release notes (at the repo root).

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,21 @@ from setuptools import setup
 
 version = "2.0.0"
 
+
+def _long_description():
+    """README + CHANGES rendered as one markdown document on PyPI."""
+    with open("README.md") as fh:
+        readme = fh.read()
+    with open("CHANGES.md") as fh:
+        changes = fh.read()
+    return readme + "\n\n" + changes
+
+
 setup(
     name="senaite.astm",
     version=version,
     description="",
-    long_description=open("README.md").read(),
+    long_description=_long_description(),
     long_description_content_type="text/markdown",
     license="GPLv2",
     # Get more strings from


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pre-deployment hygiene: `setup.py`'s `long_description` only read `README.md`, so the changelog never made it to the PyPI project page. `CHANGES.rst` also wasn't listed in any `MANIFEST.in`, so it would have been dropped from a built sdist.

## Current behavior before PR

```python
long_description=open("README.md").read(),
long_description_content_type="text/markdown",
```

PyPI page shows only the README. `CHANGES.rst` is in the git tree but not in the package metadata or the sdist manifest.

## Desired behavior after PR is merged

- Rename `CHANGES.rst` → `CHANGES.md` so it matches the markdown doc tree we just landed. Headings converted (`====` → `#`, `----` → `##`).
- `setup.py` builds `long_description` from `README.md + "\n\n" + CHANGES.md` so both render on PyPI as a single markdown document.
- New `MANIFEST.in` includes `README.md`, `CHANGES.md`, `LICENSE`, and the markdown docs tree so sdist carries them.
- `docs/README.md` link updated to point at `../CHANGES.md`.

## Tests

Configuration / packaging change — no code changes. Verified `_long_description()` concatenates correctly and exceeds 11k chars.