### PR TITLE
senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI
 - core: include CHANGES.md in setup.py long_description and add MANIFEST.in so the changelog ships in the sdist and renders on PyPI
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS
 - #66 admin: bound /stats request reads with a 5s timeout + 2 KiB cap and narrow except blocks to drop slowloris peers

--- a/src/senaite/astm/sender.py
+++ b/src/senaite/astm/sender.py
@@ -1,22 +1,26 @@
 # -*- coding: utf-8 -*-
-"""`senaite-astm-send` CLI — push captured ASTM files to a SENAITE
-LIMS push endpoint without running a TCP listener.
+"""`senaite-astm-send` CLI — push captured ASTM **or HL7 v2**
+files to a SENAITE LIMS push endpoint without running a TCP
+listener.
 
-Useful for replaying messages from `astm_messages/` directly into a
-dev / staging SENAITE instance so the consumer-side adapter (e.g.
+Useful for replaying messages from `astm_messages/` or
+`hl7_messages/` directly into a dev / staging SENAITE instance so
+the consumer-side adapter (e.g.
 `cermel.lims.adapters.astm_importer.ASTMImporter`) can be
 exercised end-to-end without the device on the wire.
 
-The `-m / --message-format` option mirrors `senaite-astm-server`'s
-flag: choose what the LIMS receives.
+The wire format is auto-detected from the leading bytes (files
+starting with ``MSH`` are HL7; everything else is ASTM). The
+`-m / --message-format` option chooses what the LIMS receives:
 
 - `json`  (default): parse each input file into an :class:`Envelope`
   and POST the typed JSON. This is what the
   `senaite.core.lis2a.import` consumer expects today.
-- `astm`  : POST the original framed ASTM bytes verbatim (legacy
-  consumers that re-parse raw payloads).
+- `astm`  : POST the original framed ASTM (or HL7) bytes verbatim
+  (legacy consumers that re-parse raw payloads).
 - `lis2a` : POST the framed-free LIS2-A flat string from
-  `metadata.lis2a` (other legacy paths).
+  `metadata.lis2a` (other legacy paths). HL7 inputs produce an
+  empty `lis2a` field and should use `json` instead.
 """
 
 import argparse
@@ -28,6 +32,7 @@ from senaite.astm import logger
 from senaite.astm.core import lims
 from senaite.astm.core.envelope import serialize_envelope
 from senaite.astm.core.lims import post_to_senaite
+from senaite.astm.transports.hl7.parser import parse as parse_hl7
 from senaite.astm.utils import parse_capture
 from senaite.astm.utils import rebuild_checksums
 from senaite.astm.wrapper import Wrapper
@@ -69,14 +74,15 @@ def _file_to_message(fh, message_format, rebuild=False,
                      substitutions=None,
                      scrub_phi=False, phi_keep=(),
                      keep_records=None, drop_records=None):
-    """Read a captured ASTM file and produce one message for
-    `post_to_senaite`.
+    """Read a captured ASTM or HL7 v2 file and produce one
+    message for `post_to_senaite`.
 
-    Captures contain raw STX/ETX-framed bytes off the wire (the
-    same format `senaite-astm-simulator` writes when it sends a
-    fixture to a listener). :func:`senaite.astm.utils.parse_capture`
-    extracts the individual frames; `Wrapper` turns them into the
-    typed envelope.
+    The wire format is auto-detected from the leading bytes:
+    inputs that start with ``MSH`` are routed through the HL7
+    parser, everything else through :func:`parse_capture` +
+    :class:`Wrapper`. Both paths converge on the same typed
+    :class:`Envelope`, so the downstream serialisation /
+    scrubbing / record-filtering logic is shared.
 
     `rebuild=True` runs :func:`rebuild_checksums` over the input
     bytes first so a hand-edited capture (sample-id swap, PHI
@@ -116,18 +122,42 @@ def _file_to_message(fh, message_format, rebuild=False,
     raw = fh.read()
     if substitutions:
         raw = _apply_substitutions(raw, substitutions)
-    if rebuild:
+    wire = _detect_wire_format(raw)
+    if wire == "astm" and rebuild:
         raw = rebuild_checksums(raw)
     if message_format == "astm":
         return raw
 
-    frames = parse_capture(raw)
-    envelope = Wrapper(frames).to_envelope()
+    envelope = _parse_envelope(raw, wire)
     if scrub_phi:
         _scrub_envelope_phi(envelope, phi_keep)
     if keep_records or drop_records:
         _filter_envelope_records(envelope, keep_records, drop_records)
     return serialize_envelope(envelope, message_format)
+
+
+def _detect_wire_format(raw):
+    """Return ``"hl7"`` when the input is an HL7 v2 message,
+    ``"astm"`` otherwise.
+
+    HL7 v2 messages start with an MSH segment (literal ``b"MSH"``).
+    ASTM captures start with ENQ / STX or a leading newline. The
+    sniff is deliberately cheap — no full parse — so a slightly
+    weird input still flows through the existing ASTM path and
+    the parser's own error becomes the failure mode.
+    """
+    if raw.lstrip().startswith(b"MSH"):
+        return "hl7"
+    return "astm"
+
+
+def _parse_envelope(raw, wire):
+    """Parse ``raw`` into an :class:`Envelope` using the parser
+    appropriate to ``wire``."""
+    if wire == "hl7":
+        return parse_hl7(raw)
+    frames = parse_capture(raw)
+    return Wrapper(frames).to_envelope()
 
 
 def _apply_substitutions(raw, substitutions):
@@ -181,6 +211,8 @@ def _scrub_envelope_phi(envelope, keep_keys=()):
         envelope.metadata.astm = ""
     if envelope.metadata.lis2a:
         envelope.metadata.lis2a = ""
+    if envelope.metadata.hl7:
+        envelope.metadata.hl7 = ""
 
 
 def _filter_envelope_records(envelope, keep, drop):
@@ -229,7 +261,9 @@ def main():
     astm_group.add_argument(
         "-i", "--infile",
         type=argparse.FileType("rb"), nargs="+",
-        help="ASTM file(s) to send to SENAITE")
+        help="ASTM or HL7 v2 file(s) to send to SENAITE. The "
+             "wire format is auto-detected from the leading "
+             "bytes (files starting with 'MSH' are HL7).")
 
     astm_group.add_argument(
         "--substitute-sample-id", dest="substitutions",

--- a/src/senaite/astm/tests/test_sender_hl7_input.py
+++ b/src/senaite/astm/tests/test_sender_hl7_input.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Tests for HL7 auto-detection on `senaite-astm-send -i`.
+
+senaite-astm-send was originally ASTM-only; this exercise
+confirms that HL7 v2 inputs (the HemoScreen fixtures shipped in
+``tests/data/hl7/``) flow through the same CLI without a
+``parse_capture`` failure, and that ``--scrub-phi`` clears the
+HL7 metadata payload alongside the ASTM ones.
+"""
+
+import io
+import json
+import os
+import unittest
+
+from senaite.astm.sender import _detect_wire_format
+from senaite.astm.sender import _file_to_message
+
+
+HERE = os.path.dirname(__file__)
+DATA_DIR = os.path.join(HERE, "data")
+HL7_FIXTURE = os.path.join(
+    DATA_DIR, "hl7", "hemoscreen_fresh_blood.hl7")
+ASTM_FIXTURE = os.path.join(DATA_DIR, "yumizen_h500.txt")
+
+
+class DetectWireFormatTest(unittest.TestCase):
+
+    def test_hl7_message_detected(self):
+        self.assertEqual(_detect_wire_format(b"MSH|^~\\&|...\r"), "hl7")
+
+    def test_hl7_message_with_leading_whitespace(self):
+        self.assertEqual(
+            _detect_wire_format(b"\n\rMSH|^~\\&|...\r"), "hl7")
+
+    def test_astm_capture_default(self):
+        # ASTM captures start with ENQ / STX or a leading newline
+        self.assertEqual(_detect_wire_format(b"\x051H|\\^&|"), "astm")
+        self.assertEqual(_detect_wire_format(b"\x021H|\\^&|\x03B7"), "astm")
+
+    def test_empty_input_routes_to_astm(self):
+        # An empty input must not crash detection; the ASTM parser
+        # will return [] frames downstream.
+        self.assertEqual(_detect_wire_format(b""), "astm")
+
+
+class HL7InputEndToEndTest(unittest.TestCase):
+
+    def _fh(self, path):
+        return io.BytesIO(open(path, "rb").read())
+
+    def test_hl7_file_yields_typed_envelope(self):
+        msg = _file_to_message(self._fh(HL7_FIXTURE), "json")
+        env = json.loads(msg)
+        # HL7 metadata carries the verbatim text; ASTM metadata
+        # stays empty.
+        self.assertTrue(env["metadata"].get("hl7"))
+        self.assertEqual(env["metadata"].get("astm", ""), "")
+        # OBX rows landed in R.
+        self.assertGreater(len(env["R"]), 0)
+
+    def test_astm_path_still_works_after_detection(self):
+        msg = _file_to_message(self._fh(ASTM_FIXTURE), "json")
+        env = json.loads(msg)
+        self.assertEqual(len(env["H"]), 1)
+
+    def test_scrub_phi_clears_hl7_metadata(self):
+        # Without scrub the verbatim HL7 text is in metadata.hl7;
+        # with scrub it must be cleared (the inner records carry
+        # PID-3 sample ids and other identifiers).
+        plain = json.loads(
+            _file_to_message(self._fh(HL7_FIXTURE), "json"))
+        scrubbed = json.loads(
+            _file_to_message(
+                self._fh(HL7_FIXTURE), "json", scrub_phi=True))
+        self.assertTrue(plain["metadata"].get("hl7"))
+        self.assertEqual(scrubbed["metadata"].get("hl7", ""), "")
+
+
+def test_suite():
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(DetectWireFormatTest))
+    suite.addTests(loader.loadTestsFromTestCase(HL7InputEndToEndTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Until now `senaite-astm-send` was ASTM-only — running it against an HL7 capture file gave a `parse_capture` failure. The CLI was also the only tool capable of one-shot "replay this file into the LIMS as JSON" for ASTM, and reaching for an alternative just because the wire format differed felt arbitrary.

## Current behavior before PR

```
$ senaite-astm-send -i hemoscreen.hl7 -m json -u http://...
# parse_capture fails — no STX found
```

## Desired behavior after PR is merged

```
$ senaite-astm-send -i hemoscreen.hl7 -m json -u http://...
# auto-detects HL7, routes through the HL7 parser, POSTs the
# typed envelope to SENAITE — same shape as the ASTM path.
```

- Cheap leading-byte sniff (`b"MSH"` → HL7, otherwise ASTM) in `_file_to_message`.
- Both paths converge on the same typed `Envelope` so the downstream serialisation / `--scrub-phi` / `--filter-records` / `--drop-records` / `--output` / `--dry-run` flags compose identically.
- `--scrub-phi` extended to also clear `envelope.metadata.hl7` (in addition to `.astm` and `.lis2a`) so HL7 replays don't leak the verbatim flat-text payload through metadata.
- `--rebuild-checksums` is silently skipped on HL7 inputs (HL7 has no per-frame checksum).

## Tests

- `DetectWireFormatTest` — HL7 / HL7-with-leading-whitespace / ENQ-ASTM / STX-ASTM / empty-input.
- `HL7InputEndToEndTest` — bundled HemoScreen fixture flows through `-m json` and lands OBX rows in `R`; ASTM Yumizen path still works; `--scrub-phi` clears `metadata.hl7`.
- Full suite still green (454 + 8 = 462 passed locally).