### PR TITLE
roche_cobas_c111: declare missing OrderRecord.test, Patient.laboratory_id, Comment fields and rename modified_at to reported_at

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- roche_cobas_c111: declare Order test (repeated), Patient laboratory_id and Comment source/data/ctype, rename Order modified_at to reported_at
 - roche_cobas_c311: use DateField for PatientRecord.birthdate to match the spec DT (YYYYMMDD) type
 - senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI
 - core: include CHANGES.md in setup.py long_description and add MANIFEST.in so the changelog ships in the sdist and renders on PyPI

--- a/src/senaite/astm/instruments/roche_cobas_c111.py
+++ b/src/senaite/astm/instruments/roche_cobas_c111.py
@@ -9,6 +9,7 @@ from senaite.astm.fields import ComponentField
 from senaite.astm.fields import ConstantField
 from senaite.astm.fields import DateTimeField
 from senaite.astm.fields import NotUsedField
+from senaite.astm.fields import RepeatedComponentField
 from senaite.astm.fields import SetField
 from senaite.astm.fields import TextField
 from senaite.astm.mapping import Component
@@ -60,6 +61,10 @@ class PatientRecord(records.PatientRecord):
     P|1||[SampleIDpart]
     """
 
+    # 8.1.4: Practice-assigned Patient ID. Carries the manually-entered
+    # Sample ID in NPT mode per spec section 7.2.2.4.
+    laboratory_id = TextField()
+
 
 class OrderRecord(records.OrderRecord):
 
@@ -86,16 +91,44 @@ class OrderRecord(records.OrderRecord):
         )
     )
 
+    # 9.4.5: Universal Test ID. Repeated field carrying up to 60
+    # ordered tests, e.g. ^^^211\^^^100\^^^744. Without this
+    # declaration the base NotUsedField swallows all ordered tests
+    # on host-bound orders.
+    test = RepeatedComponentField(
+        Component.build(
+            NotUsedField(name="_"),
+            NotUsedField(name="__"),
+            NotUsedField(name="___"),
+            TextField(name="test_id"),
+            TextField(name="treatment"),
+        )
+    )
+
     # 9.4.6: Priority
     priority = SetField(values=["R", "S"])
 
     # 9.4.23: Date/Time Reported
-    modified_at = DateTimeField()
+    reported_at = DateTimeField()
 
 
 class CommentRecord(records.CommentRecord):
     """Comment Record (C)
     """
+
+    # Always "I" (instrument).
+    source = TextField()
+
+    # Flag code ^ flag comment, repeated.
+    data = RepeatedComponentField(
+        Component.build(
+            TextField(name="flag_code"),
+            TextField(name="flag_comment"),
+        )
+    )
+
+    # Always "I" (instrument flag comment).
+    ctype = TextField()
 
 
 class ResultRecord(records.ResultRecord):

--- a/src/senaite/astm/tests/data/envelopes/cobas_c111.json
+++ b/src/senaite/astm/tests/data/envelopes/cobas_c111.json
@@ -1,10 +1,10 @@
 {
   "C": [
     {
-      "ctype": null,
-      "data": null,
+      "ctype": "I",
+      "data": [],
       "seq": "1",
-      "source": null,
+      "source": "I",
       "type": "C"
     }
   ],
@@ -92,13 +92,12 @@
       "laboratory_field_1": null,
       "laboratory_field_2": null,
       "location_ward": null,
-      "modified_at": null,
       "physician": null,
       "physician_phone": null,
       "priority": "S",
       "received_at": null,
       "report_type": null,
-      "reported_at": null,
+      "reported_at": "20230803131713",
       "requested_at": null,
       "reserved": null,
       "sample_id": {
@@ -109,7 +108,7 @@
       "sampled_at": null,
       "seq": "1",
       "specimen_service": null,
-      "test": null,
+      "test": [],
       "type": "O",
       "user_field_1": null,
       "user_field_2": null,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Audit of the `roche_cobas_c111` schema module against the Roche cobas c111 Host Interface Manual (v2.1) surfaced four discrepancies. All of them are field declarations that fell through to the base record's `NotUsedField`, so the corresponding values were silently discarded during parsing.

## Current behavior before PR

- `OrderRecord` does not declare field 9.4.5 `Universal Test ID`. Spec documents it as a repeated component (`^^^211\^^^100\^^^744`, up to 60 tests). The base `OrderRecord.test = NotUsedField()` drops every ordered test on host-bound order messages.
- `PatientRecord` does not declare 8.1.4 `Practice-assigned Patient ID`. Per spec section 7.2.2.4, this carries the manually-entered Sample ID in NPT mode; today it is dropped.
- `OrderRecord.modified_at` does not match the base name (`reported_at`) used by every other module and by the spec label (9.4.23 "Date/Time Reported"). The data lands under a non-standard key.
- `CommentRecord` does not declare `source`, `data` or `ctype`. Spec 11.x mandates all three (source/ctype always "I"; data is repeated `flag_code^flag_comment`). All instrument flag comments are dropped.

## Desired behavior after PR is merged

- `OrderRecord.test` is a `RepeatedComponentField` carrying `(_, __, ___, test_id, treatment)` so ordered test IDs survive parsing.
- `PatientRecord.laboratory_id = TextField()` preserves the NPT-mode sample ID.
- `OrderRecord.reported_at = DateTimeField()` replaces `modified_at` so the field name matches the rest of the project.
- `CommentRecord` declares `source` (TextField), `data` (RepeatedComponentField with `flag_code` + `flag_comment`) and `ctype` (TextField), so instrument flag comments are preserved.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html