### PR TITLE
roche_cobas_c311: use DateField for PatientRecord.birthdate (spec DT, YYYYMMDD)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- roche_cobas_c311: use DateField for PatientRecord.birthdate to match the spec DT (YYYYMMDD) type
 - senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI
 - core: include CHANGES.md in setup.py long_description and add MANIFEST.in so the changelog ships in the sdist and renders on PyPI
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS

--- a/src/senaite/astm/instruments/roche_cobas_c311.py
+++ b/src/senaite/astm/instruments/roche_cobas_c311.py
@@ -7,6 +7,7 @@ from senaite.astm.core.instrument import Instrument
 from senaite.astm.core.instrument import register_instrument
 from senaite.astm.fields import ComponentField
 from senaite.astm.fields import ConstantField
+from senaite.astm.fields import DateField
 from senaite.astm.fields import DateTimeField
 from senaite.astm.fields import RepeatedComponentField
 from senaite.astm.fields import SetField
@@ -49,7 +50,8 @@ class HeaderRecord(records.HeaderRecord):
 class PatientRecord(records.PatientRecord):
     """Patient Information Record (P)
     """
-    birthdate = DateTimeField()
+    # 8.1.8: Date of Birth, DT (YYYYMMDD) per spec E-11.
+    birthdate = DateField()
     sex = TextField()
     special_1 = ComponentField(
         Component.build(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Audit of `roche_cobas_c311` against the Roche cobas c311 ASTM Interface Manual (2013, v14) found that `PatientRecord.birthdate` was declared as `DateTimeField` (14-character YYYYMMDDHHMMSS) but the spec (appendix E-11, field 8) types it as `DT` (8-character YYYYMMDD).

## Current behavior before PR

`PatientRecord.birthdate = DateTimeField()` — accepts and emits 14-character timestamps that the instrument never sends, so parsed envelopes carry an ambiguous slot.

## Desired behavior after PR is merged

`PatientRecord.birthdate = DateField()` — matches the spec DT type and the convention used by every other patient-record subclass in this project.