### PR TITLE
horiba_pentra_xlr: widen report_type to accept 'I' and fix CommentRecord.source tuple syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 2.0.0
 
 - astm transport: buffer data_received across TCP segments so chunked ASTM frames are reassembled instead of NAKed
+- horiba_pentra_xlr: widen OrderRecord.report_type to accept the spec value 'I' (unvalidated) and fix CommentRecord.source values to be a 1-tuple
 - roche_cobas_c111: declare Order test (repeated), Patient laboratory_id and Comment source/data/ctype, rename Order modified_at to reported_at
 - roche_cobas_c311: use DateField for PatientRecord.birthdate to match the spec DT (YYYYMMDD) type
 - senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI

--- a/src/senaite/astm/instruments/horiba_pentra_xlr.py
+++ b/src/senaite/astm/instruments/horiba_pentra_xlr.py
@@ -101,7 +101,9 @@ class OrderRecord(records.OrderRecord):
     report_type = SetField(
         field=TextField(),
         length=1,
-        values=("F", "C"))  # F: final; C: correction
+        # F: final; C: correction; I: unvalidated (when
+        # unconditional validation is off, spec 9.4.26)
+        values=("F", "C", "I"))
 
 
 class CommentRecord(records.CommentRecord):
@@ -111,7 +113,7 @@ class CommentRecord(records.CommentRecord):
     source = SetField(
         field=TextField(),
         length=1,
-        values=("I"))
+        values=("I",))
 
     # Text (Refer to Table 23 - Analytical alarms, page 18; Table 24 - Analyzer
     # alarms, page 18; Table 25 - Suspected pathologies, page 18.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Audit of `horiba_pentra_xlr` against the Horiba Pentra XLR ASTM interface manual surfaced two small schema issues in the Order and Comment records.

## Current behavior before PR

- `OrderRecord.report_type` is a `SetField(values=("F", "C"))`. Spec 9.4.26 (Note 4) also lists `I` (Result unvalidated, used when unconditional validation is off). `I` is logged as unexpected at parse time.
- `CommentRecord.source` is declared `SetField(values=("I"))`. Because `("I")` is a string, not a tuple, the SetField allow-list silently becomes `set('I')` — equivalent to a one-element tuple by accident, but semantically wrong and easy to break when a second value is added.

## Desired behavior after PR is merged

- `OrderRecord.report_type` accepts `('F', 'C', 'I')`.
- `CommentRecord.source` uses `values=('I',)` so the allow-list is unambiguous.