### PR TITLE
horiba_yumizen_h5xx: drop unused PatientRecord.unknown_1 / unknown_2 placeholders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- horiba_yumizen_h5xx: drop unused PatientRecord.unknown_1 / unknown_2 placeholders
 - senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI
 - core: include CHANGES.md in setup.py long_description and add MANIFEST.in so the changelog ships in the sdist and renders on PyPI
 - #64 core/lims: enforce a default HTTP timeout on Session.post / .get to prevent thread-pool starvation on a hung LIMS

--- a/src/senaite/astm/instruments/horiba_yumizen_h5xx.py
+++ b/src/senaite/astm/instruments/horiba_yumizen_h5xx.py
@@ -43,8 +43,6 @@ class HeaderRecord(records.HeaderRecord):
 class PatientRecord(records.PatientRecord):
     """Patient Information Record (P)
     """
-    unknown_1 = NotUsedField()
-    unknown_2 = NotUsedField()
 
 
 class OrderRecord(records.OrderRecord):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`HoribaYumizenH5xx.PatientRecord` declares two `NotUsedField` placeholders named `unknown_1` and `unknown_2`. Auditing against real envelopes (`tests/data/envelopes/yumizen_h500.json`) confirms neither slot is ever populated. They are noise that pollutes the envelope output.

## Current behavior before PR

Every parsed Yumizen envelope carries `"unknown_1": null, "unknown_2": null` under `P[0]`.

## Desired behavior after PR is merged

The placeholders are removed. The base `PatientRecord` already provides the standard ASTM patient fields, all of which remain in place. No downstream consumer reads `unknown_1` / `unknown_2`.