### PR TITLE
astm transport: buffer data_received across TCP segments so chunked ASTM frames are reassembled instead of NAKed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- astm transport: buffer data_received across TCP segments so chunked ASTM frames are reassembled instead of NAKed
 - roche_cobas_c111: declare Order test (repeated), Patient laboratory_id and Comment source/data/ctype, rename Order modified_at to reported_at
 - roche_cobas_c311: use DateField for PatientRecord.birthdate to match the spec DT (YYYYMMDD) type
 - senaite-astm-send: auto-detect ASTM vs HL7 v2 inputs so HL7 captures can be replayed with the same CLI

--- a/src/senaite/astm/tests/test_astm_protocol.py
+++ b/src/senaite/astm/tests/test_astm_protocol.py
@@ -116,3 +116,53 @@ class ASTMProtocolTest(ASTMTestBase):
             self.protocol.connection_lost(None)
 
         self.assertIn("WARNING", [r.levelname for r in cm.records])
+
+    def test_chunked_frame_assembled_across_recvs(self):
+        """A complete ASTM frame split across two TCP segments
+        must be reassembled into a single dispatched message, with
+        the matching ACK going back to the client. Regression test
+        for the production cobas c111 transmission where the R
+        record arrived as two recvs and the continuation bytes
+        were dropped as un-dispatchable."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+        self.protocol.data_received(ENQ)
+
+        # Hand-crafted R frame split mid-data. The checksum
+        # matches the full frame body once reassembled.
+        frame = (
+            b"\x024R|1|^^^734|3.0|umol/L||N||F||$SYS$||"
+            b"20260603110046\r\x03B2\r\n"
+        )
+        # Split in the middle of the date field, just like the log
+        first, second = frame[:45], frame[45:]
+        self.assertNotIn(b"\x03", first,
+                         "split point must be before the terminator")
+
+        self.protocol.data_received(first)
+        # Nothing dispatched yet — buffer is short.
+        self.assertEqual(len(self.protocol.messages), 0)
+
+        self.protocol.data_received(second)
+        # Now the frame is complete and stored as one message.
+        self.assertEqual(len(self.protocol.messages), 1)
+        # And the response to the (now complete) frame was an ACK.
+        transport.write.assert_called_with(ACK)
+
+    def test_two_full_frames_in_one_recv(self):
+        """When a single TCP segment carries two complete frames
+        back to back, both must be dispatched and ACKed."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+        self.protocol.data_received(ENQ)
+
+        # Two minimal valid frames concatenated.
+        frame_a = b"\x021H|\\^&\r\x03E5\r\n"
+        frame_b = b"\x022P|1\r\x033F\r\n"
+        self.protocol.data_received(frame_a + frame_b)
+
+        self.assertEqual(len(self.protocol.messages), 2)
+        # Each frame produced an ACK; the last write is the second ACK.
+        self.assertEqual(
+            [c.args[0] for c in transport.write.call_args_list[-2:]],
+            [ACK, ACK])

--- a/src/senaite/astm/transports/astm/protocol.py
+++ b/src/senaite/astm/transports/astm/protocol.py
@@ -17,6 +17,8 @@ from senaite.astm import logger
 from senaite.astm.constants import ACK
 from senaite.astm.constants import ENQ
 from senaite.astm.constants import EOT
+from senaite.astm.constants import ETB
+from senaite.astm.constants import ETX
 from senaite.astm.constants import NAK
 from senaite.astm.constants import STX
 from senaite.astm.core.instrument import find_raw_data_handler
@@ -60,6 +62,14 @@ class ASTMProtocol(asyncio.Protocol):
         self.chunks = []
         self.messages = []
         self.in_transfer_state = False
+        # Per-connection input buffer. TCP delivers byte streams,
+        # not framed messages, so a single ASTM frame can arrive
+        # split across multiple `data_received` calls (typically
+        # the large M / R frames). Accumulating into a buffer and
+        # slicing complete units off the front avoids the previous
+        # behaviour where a partial frame would be NAKed and the
+        # continuation bytes would be dropped as un-dispatchable.
+        self.buffer = b""
 
     # ------------------------------------------------------------------
     # asyncio.Protocol callbacks
@@ -108,10 +118,95 @@ class ASTMProtocol(asyncio.Protocol):
         logger.debug("-> Data received from {!s}: {!r}".format(
             self.client, data))
         self.restart_timer()
-        response = self.handle_data(data)
-        if response is not None:
-            logger.debug("<- Sending response: {!r}".format(response))
-            self.transport.write(response)
+        self.buffer += data
+
+        # Non-ASTM wire formats (mini_vidas, spotchem) ship a
+        # single packet that doesn't follow ENQ/STX/EOT framing.
+        # Their `raw_data_regex` matches the full payload, so we
+        # only invoke the raw handler once the buffer holds a
+        # complete match. Until then the bytes stay buffered and
+        # this branch returns; a later `data_received` retries.
+        if not self.in_transfer_state:
+            instrument = find_raw_data_handler(self.buffer)
+            if instrument is not None:
+                payload = self.buffer
+                self.buffer = b""
+                response = instrument.handle_raw_data(self, payload)
+                if response is not None:
+                    logger.debug(
+                        "<- Sending response: {!r}".format(response))
+                    self.transport.write(response)
+                return
+
+        # ASTM framing: peel one logical unit (single-byte signal
+        # or a complete STX..ETX/ETB+checksum frame) off the front
+        # of the buffer at a time, dispatch it, and write whatever
+        # response the dispatch produced. Stop when the buffer no
+        # longer holds a complete unit so the remaining bytes can
+        # be joined with the next `data_received` payload.
+        while True:
+            unit = self._pop_one_unit()
+            if unit is None:
+                return
+            response = self.handle_data(unit)
+            if response is not None:
+                logger.debug(
+                    "<- Sending response: {!r}".format(response))
+                self.transport.write(response)
+
+    def _pop_one_unit(self):
+        """Slice one ASTM unit off the front of :attr:`buffer`.
+
+        Returns the unit bytes (single-byte signal or complete
+        frame) on success. Returns None when the buffer is empty
+        or holds a partial frame whose terminator/checksum has
+        not arrived yet.
+
+        Leading garbage (bytes that are not a known signal byte
+        and not an STX) is skipped one byte at a time with a
+        warning; this matches the previous behaviour where the
+        same bytes would have hit `default_handler` and been
+        logged at ERROR.
+        """
+        if not self.buffer:
+            return None
+
+        first = self.buffer[:1]
+        if first in (ENQ, ACK, NAK, EOT):
+            self.buffer = self.buffer[1:]
+            return first
+
+        if first != STX:
+            logger.warning(
+                "Skipping unexpected byte %r in buffer", first)
+            self.buffer = self.buffer[1:]
+            return self._pop_one_unit()
+
+        # STX-prefixed frame: locate the first ETX or ETB and
+        # require the two checksum bytes that follow.
+        etx = self.buffer.find(ETX, 1)
+        etb = self.buffer.find(ETB, 1)
+        candidates = [c for c in (etx, etb) if c >= 0]
+        if not candidates:
+            return None
+        terminator = min(candidates)
+        end = terminator + 3  # +1 for terminator, +2 for checksum
+        if len(self.buffer) < end:
+            return None
+
+        # Many instruments wrap frames in `\r\n` for serial-line
+        # parity with classic ASTM. Include those trailing bytes
+        # in the returned frame so downstream helpers that key off
+        # the wire shape (notably `is_chunked_message`, which
+        # expects the ETB to sit at `len(frame) - 5`) keep working.
+        tail = end
+        if self.buffer[tail:tail + 1] == b"\r":
+            tail += 1
+        if self.buffer[tail:tail + 1] == b"\n":
+            tail += 1
+        frame = self.buffer[:tail]
+        self.buffer = self.buffer[tail:]
+        return frame
 
     # ------------------------------------------------------------------
     # Timer management
@@ -157,6 +252,7 @@ class ASTMProtocol(asyncio.Protocol):
         self.chunks = []
         self.messages = []
         self.in_transfer_state = False
+        self.buffer = b""
 
     # ------------------------------------------------------------------
     # Byte-level dispatch


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The ASTM transport in `senaite/astm/transports/astm/protocol.py` dispatches `data_received` directly into `handle_data` without buffering, so any ASTM frame that the OS delivers in more than one TCP segment is parsed as two separate units: the first segment is treated as a complete-but-malformed frame (it has no terminator), and the continuation bytes are dropped at `default_handler` with `Unable to dispatch data`. The session then fails at EOT with `Incomplete frame data ... Expected trailing <CR><ETX> or <ETB> chars`.

This was observed in production on a cobas c111 R record:

```
... b'\x024R|1|^^^734|3.0|umol/L||N||F||$SYS$||202606'        <- segment 1
... b'03110046\r\x17C6\r\n'                                    <- segment 2
ERROR Unable to dispatch data: b'03110046\r\x17C6\r\n'
ERROR Failed to build envelope ... Incomplete frame data ... 2\x03
```

The HL7 transport in the same project already handles this correctly via a per-connection `self.buffer` and `extract_messages` (see `transports/hl7/protocol.py`).

## Current behavior before PR

- `ASTMProtocol.data_received(data)` calls `handle_data(data)` once per recv.
- A frame split across two TCP segments produces one bad frame and one un-dispatchable continuation.
- The session is dropped at EOT, with the captured file holding a truncated frame on disk.

## Desired behavior after PR is merged

- `ASTMProtocol` accumulates bytes in `self.buffer` and slices one logical unit at a time off the front: single-byte signals (ENQ/ACK/NAK/EOT) or a complete `STX..ETX/ETB + 2-byte checksum (+ optional CRLF)` frame.
- A frame split across two recvs is reassembled and dispatched as one unit; the matching ACK is written back. The HL7 transport's `self.buffer` pattern is now mirrored for ASTM.
- Non-ASTM wire formats (mini_vidas, spotchem) keep their existing `find_raw_data_handler` shortcut — the raw-data dispatch runs against the accumulated buffer so a fragmented raw packet is held until the regex matches, instead of being chopped at the first STX-looking byte.
- `reset_session_state` and `close_connection` clear the buffer so a stuck partial frame from a previous session never contaminates the next one.
- Frames continue to include the trailing CRLF where present, so `is_chunked_message` (which keys off `len(frame) - 5 == ETB index`) keeps working unchanged.

Regression coverage in `tests/test_astm_protocol.py`:

- `test_chunked_frame_assembled_across_recvs` feeds a real-shaped R frame in two TCP segments and asserts a single dispatched message + ACK.
- `test_two_full_frames_in_one_recv` confirms that two complete frames concatenated into one recv are both dispatched and both ACKed.

Full test suite stays green (467 passed, 1 skipped). The pre-existing 21,245 captured cobas c111 messages and 11,855 Yumizen H5xx messages continue to parse at the same rates (no regression). The fix applies to traffic going forward: previously truncated captures on disk remain truncated and need to be re-captured.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html