### PR TITLE
Fix reassembly of ASTM frames split across multiple TCP reads

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #78 Fix reassembly of ASTM frames split across multiple TCP reads
 - #61 Add client (connect) mode to actively connect out to passive instruments
 - #24 Add Abbott ARCHITECT System import schema
 - #23 Add Cepheid GeneXpert import schema

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -6,8 +6,12 @@ import os
 from senaite.astm import adapter_registry
 from senaite.astm import logger
 from senaite.astm.constants import ACK
+from senaite.astm.constants import CR
 from senaite.astm.constants import ENQ
 from senaite.astm.constants import EOT
+from senaite.astm.constants import ETB
+from senaite.astm.constants import ETX
+from senaite.astm.constants import LF
 from senaite.astm.constants import NAK
 from senaite.astm.constants import STX
 from senaite.astm.exceptions import InvalidState
@@ -41,6 +45,7 @@ class ASTMProtocol(asyncio.Protocol):
         self.transport = None
         self.client = None
         self.timer = None
+        self.buffer = b""
         self.chunks = []
         self.messages = []
         self.in_transfer_state = False
@@ -102,6 +107,14 @@ class ASTMProtocol(asyncio.Protocol):
 
     def data_received(self, data):
         """Called when some data is received.
+
+        TCP does not preserve message boundaries: a single ASTM frame can be
+        split across several reads (common with serial-to-LAN gateways that
+        forward a slow serial stream), and conversely several control bytes
+        and/or frames can arrive in a single read. We therefore accumulate
+        incoming bytes in a buffer and only dispatch *complete* tokens:
+        single control bytes (ENQ/ACK/NAK/EOT), or a full frame terminated by
+        <LF>.
         """
         logger.debug("-> Data received from {!s}: {!r}".format(
             self.client, data))
@@ -110,11 +123,54 @@ class ASTMProtocol(asyncio.Protocol):
         # -> this ensures the next data is received within the timeout
         self.restart_timer()
 
-        # handle the data
-        response = self.handle_data(data)
-        if response is not None:
-            logger.debug("<- Sending response: {!r}".format(response))
-            self.transport.write(response)
+        self.buffer += data
+        for token in self.iter_tokens():
+            response = self.handle_data(token)
+            if response is not None:
+                logger.debug("<- Sending response: {!r}".format(response))
+                self.transport.write(response)
+
+    def iter_tokens(self):
+        """Yield complete protocol tokens from the receive buffer.
+
+        A token is either a single control byte (<ENQ>/<ACK>/<NAK>/<EOT>) or a
+        whole ASTM frame: ``<STX> FN ... (<ETX>|<ETB>) C1 C2 [<CR><LF>]``. A
+        frame is only emitted once its end marker *and* its two checksum bytes
+        have arrived; partial frames stay in the buffer until the rest comes.
+        The trailing <CR>/<LF> is optional, so this works whether the sender
+        terminates frames with <CR><LF> (real instruments) or not.
+        """
+        while self.buffer:
+            first = self.buffer[:1]
+            if first in (ENQ, ACK, NAK, EOT):
+                self.buffer = self.buffer[1:]
+                yield first
+            elif first == STX:
+                # find the frame end marker (<ETX> final, or <ETB> chunked)
+                markers = [i for i in (self.buffer.find(ETX),
+                                       self.buffer.find(ETB)) if i != -1]
+                if not markers:
+                    return  # no terminator yet, wait for more data
+                end = min(markers)
+                # the 2 checksum bytes follow the end marker
+                if len(self.buffer) < end + 3:
+                    return  # checksum not fully arrived yet
+                frame_end = end + 3
+                # consume an optional trailing <CR> and/or <LF>
+                while (self.buffer[frame_end:frame_end + 1] in (CR, LF)):
+                    frame_end += 1
+                frame, self.buffer = (
+                    self.buffer[:frame_end], self.buffer[frame_end:])
+                yield frame
+            elif first in (CR, LF):
+                # inter-frame whitespace (e.g. a <CR><LF> split from its
+                # frame across reads): ignore silently
+                self.buffer = self.buffer[1:]
+            else:
+                # stray/unexpected leading byte (e.g. line noise): drop it so
+                # we don't stall on it, and keep scanning
+                logger.warning("Discarding unexpected byte: %r", first)
+                self.buffer = self.buffer[1:]
 
     def handle_data(self, data):
         """Process incoming data

--- a/src/senaite/astm/protocol.py
+++ b/src/senaite/astm/protocol.py
@@ -14,7 +14,6 @@ from senaite.astm.constants import ETX
 from senaite.astm.constants import LF
 from senaite.astm.constants import NAK
 from senaite.astm.constants import STX
-from senaite.astm.exceptions import InvalidState
 from senaite.astm.exceptions import NotAccepted
 from senaite.astm.interfaces import IDataHandler
 from senaite.astm.utils import is_chunked_message
@@ -125,7 +124,14 @@ class ASTMProtocol(asyncio.Protocol):
 
         self.buffer += data
         for token in self.iter_tokens():
-            response = self.handle_data(token)
+            # A single malformed/unexpected token must never tear down the
+            # connection: log it and carry on with the next token.
+            try:
+                response = self.handle_data(token)
+            except Exception as exc:
+                logger.error("Error handling token {!r}: {!r}".format(
+                    token, exc))
+                continue
             if response is not None:
                 logger.debug("<- Sending response: {!r}".format(response))
                 self.transport.write(response)
@@ -216,20 +222,28 @@ class ASTMProtocol(asyncio.Protocol):
     def on_ack(self, data):
         """Calls on <ACK> message receiving."""
         logger.debug("on_ack: %r", data)
-        raise NotAccepted("Server should not be ACKed.")
+        # We are the receiver and should never be ACKed. Ignore rather than
+        # raise: an exception here would be fatal to the connection.
+        logger.warning("Unexpected ACK received; ignoring")
 
     def on_nak(self, data):
         """Calls on <NAK> message receiving."""
         logger.debug("on_nak: %r", data)
-        raise NotAccepted("Server should not be NAKed.")
+        # As above: ignore an unexpected NAK instead of tearing down the link.
+        logger.warning("Unexpected NAK received; ignoring")
 
     def on_eot(self, data):
         """Calls on <EOT> message receiving."""
         logger.debug("on_eot: %r", data)
 
         if not self.in_transfer_state:
-            self.close_connection()
-            raise InvalidState("Server is not ready to accept EOT message.")
+            # Stray <EOT> outside a transfer: instruments emit these between
+            # sessions (and in <EOT>/<ENQ> bursts while establishing). Ignore
+            # it and stay connected -- raising here is fatal to the asyncio
+            # connection and would force a needless reconnect.
+            logger.warning("Received EOT outside a transfer; ignoring")
+            self.discard_env()
+            return
 
         # stop any running timer
         self.cancel_timer()

--- a/src/senaite/astm/tests/test_astm_protocol.py
+++ b/src/senaite/astm/tests/test_astm_protocol.py
@@ -85,3 +85,44 @@ class ASTMProtocolTest(ASTMTestBase):
 
         # Protocol should be no longer in transfer state
         self.assertFalse(self.protocol.in_transfer_state)
+
+    def test_fragmented_frame_reassembly(self):
+        """A single frame split across many reads (as serial-to-LAN gateways
+        do) must be reassembled, not treated as several broken frames.
+        """
+        transport = self.get_mock_transport()
+        self.protocol.transport = transport
+        self.protocol.connection_made(transport)
+
+        # Establish the session
+        self.protocol.data_received(ENQ)
+        transport.write.assert_called_with(ACK)
+
+        # Take a real frame and feed it ONE BYTE AT A TIME
+        path = self.get_instrument_file_path("yumizen_h500.txt")
+        frame = self.read_file_lines(path)[0]
+        transport.write.reset_mock()
+        for i in range(len(frame)):
+            self.protocol.data_received(frame[i:i + 1])
+
+        # Exactly one complete message was collected ...
+        self.assertEqual(len(self.protocol.messages), 1)
+        # ... and the protocol answered with a single ACK (never a NAK)
+        transport.write.assert_called_once_with(ACK)
+
+    def test_multiple_tokens_in_one_read(self):
+        """Several control bytes / frames arriving in a single read must all
+        be dispatched.
+        """
+        transport = self.get_mock_transport()
+        self.protocol.transport = transport
+        self.protocol.connection_made(transport)
+
+        path = self.get_instrument_file_path("yumizen_h500.txt")
+        frames = self.read_file_lines(path)
+        # ENQ + first two frames concatenated into a single chunk
+        blob = ENQ + frames[0] + frames[1]
+        self.protocol.data_received(blob)
+
+        # both frames were collected from the one read
+        self.assertEqual(len(self.protocol.messages), 2)

--- a/src/senaite/astm/tests/test_astm_protocol.py
+++ b/src/senaite/astm/tests/test_astm_protocol.py
@@ -110,6 +110,32 @@ class ASTMProtocolTest(ASTMTestBase):
         # ... and the protocol answered with a single ACK (never a NAK)
         transport.write.assert_called_once_with(ACK)
 
+    def test_stray_eot_does_not_drop_connection(self):
+        """A stray EOT (and EOT/ENQ bursts) outside a transfer must be
+        ignored, not raise -- raising is fatal to the asyncio connection.
+        """
+        transport = self.get_mock_transport()
+        self.protocol.transport = transport
+        self.protocol.connection_made(transport)
+
+        # EOT before any ENQ: must not raise, must not enter transfer state
+        self.protocol.data_received(EOT)
+        self.assertFalse(self.protocol.in_transfer_state)
+
+        # an EOT/ENQ/EOT burst must not raise either; the ENQ still
+        # establishes and gets ACKed
+        self.protocol.data_received(EOT + ENQ + EOT)
+        transport.write.assert_called_with(ACK)
+
+    def test_unexpected_ack_nak_ignored(self):
+        """Unexpected ACK/NAK (we are the receiver) are ignored, not raised."""
+        transport = self.get_mock_transport()
+        self.protocol.transport = transport
+        self.protocol.connection_made(transport)
+        # neither of these should raise
+        self.protocol.data_received(ACK)
+        self.protocol.data_received(NAK)
+
     def test_multiple_tokens_in_one_read(self):
         """Several control bytes / frames arriving in a single read must all
         be dispatched.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Make the ASTM protocol robust against real serial-to-LAN gateways, which — unlike the loopback simulator used in tests — deliver the byte stream in arbitrary chunks and emit stray control bytes between sessions. Two related fixes:

1. Reassemble frames split across TCP reads
  
TCP does not preserve message boundaries, so a single ASTM frame can be delivered across several reads (and, conversely, several frames/control bytes can arrive in one read). This is the norm with serial-to-LAN gateways (Moxa NPort, Lantronix UDS) that forward a slow serial stream in small TCP segments.
  
data_received() previously treated each read as one complete frame: a fragment such as `b'\x021H|\\^&|||A`' was checksum-validated on its own, failed, and was NAKed, while the trailing bytes ('`RCHITECT^...`') could not be dispatched -- the instrument retransmitted and the session never completed. Confirmed against an Abbott ARCHITECT ci4100 behind a Lantronix gateway.

`data_received()` now appends to a per-connection buffer and `iter_tokens()` yields only complete tokens: a single control byte (`ENQ/ACK/NAK/EOT`), or a whole frame up to `STX...(ETX|ETB)` + 2 checksum bytes, consuming an optional trailing `CR/LF`. Partial frames stay buffered until the rest arrives. Downstream handling is unchanged, so this is transparent to both server (listen) and client (connect) modes.

2. Don't let unexpected control bytes tear down the connection

Raising inside an asyncio protocol's `data_received()` is fatal -- it drops the connection. Several handlers raised on input that instruments legitimately send, so a stray byte forced a full disconnect/reconnect instead of being shrugged off:
  
- `on_eot()` raised `InvalidState` when an `<EOT>` arrived outside a transfer, but instruments emit stray `<EOT>` (and `<EOT>/<ENQ>` bursts) between sessions and while establishing -- observed live from the ARCHITECT, which churned the client connection (disconnect + 5s reconnect) repeatedly.
- `on_ack()/on_nak()` raised `NotAccepted` on any `<ACK>/<NAK>`; as the receiver we should simply ignore these.

These now log and ignore instead of raising, and `data_received()` wraps `handle_data()` in try/except as a backstop so no single malformed token can drop the link. Removes the now-unused `InvalidState` import.

The simulator writes each frame in a single send over loopback, so tests never fragmented and never sent stray control bytes. Adds protocol tests: a frame fed one byte at a time, multiple tokens in a single read, a stray `<EOT>` (and `<EOT>/<ENQ>/<EOT>` burst) that must not drop the connection, and unexpected `<ACK>/<NAK>` that are ignored.
  
## Current behavior before PR

The protocol assumed one TCP read = one complete ASTM frame. `data_received()` ran each chunk straight through `handle_data()`, checksum-validating it as if it were a whole frame, and raised on unexpected control bytes. Both assumptions break against real serial-to-LAN gateways:
  
- A frame split across reads (e.g. `b'\x021H|\\^&|||A'` then `b'RCHITECT^...'`) fails the checksum on its first fragment and is NAKed; the trailing bytes can't be dispatched. The instrument retransmits, the fragmentation repeats, and the session never completes — no message is received.
- Several tokens arriving in a single read (e.g. `ENQ` immediately followed by a frame) were not all processed.
- A stray `<EOT>` outside a transfer (`on_eot` → `InvalidState`), or any `<ACK>/<NAK>` (`on_ack/on_nak` → `NotAccepted`), raised inside `data_received()` and tore down the connection, forcing a reconnect.

Confirmed end-to-end against an Abbott ARCHITECT ci4100 behind a Lantronix gateway: connection established, `<ENQ>/<ACK>` fine, but every data frame was NAKed, and stray `<EOT>/<ENQ>` bursts repeatedly crashed the connection.

## Desired behavior after PR is merged

The protocol reassembles frames regardless of how TCP splits or coalesces the byte stream, and tolerates stray traffic:

- `data_received()` buffers, and `iter_tokens()` emits only complete tokens — a single control byte, or a whole frame up to `STX…(ETX|ETB)` + 2 checksum bytes (optional trailing `CR/LF)`. Partial frames stay buffered; multiple tokens in one read are each dispatched.
- Unexpected/stray control bytes are non-fatal: `on_eot()` outside a transfer and unexpected `on_ack()/on_nak()` log and ignore, and handle_data() is wrapped so no single token can drop the connection.

Result: fragmented frames are received and ACKed correctly and the session completes — verified against the Abbott ARCHITECT ci4100 via Lantronix (full `H/P/O/R/C/L` message parsed) — and stray `<EOT>/<ENQ>` bursts no longer cause reconnect churn. Transparent to both server (`--listen`) and client (`--connect`) modes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
