### PR TITLE
Fix stray control bytes tearing down the ASTM connection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## 2.0.0
 
-- Parse the documented Yumizen FLOATLE framing into structured points and populations
+- #80 Parse the documented Yumizen FLOATLE framing into structured points and populations
+- #79 Fix stray control bytes tearing down the ASTM connection
 - astm transport: buffer data_received across TCP segments so chunked ASTM frames are reassembled instead of NAKed
 - horiba_pentra_xlr: widen OrderRecord.report_type to accept the spec value 'I' (unvalidated) and fix CommentRecord.source values to be a 1-tuple
 - roche_cobas_c111: declare Order test (repeated), Patient laboratory_id and Comment source/data/ctype, rename Order modified_at to reported_at

--- a/src/senaite/astm/tests/test_astm_protocol.py
+++ b/src/senaite/astm/tests/test_astm_protocol.py
@@ -166,3 +166,40 @@ class ASTMProtocolTest(ASTMTestBase):
         self.assertEqual(
             [c.args[0] for c in transport.write.call_args_list[-2:]],
             [ACK, ACK])
+
+    def test_stray_eot_does_not_drop_connection(self):
+        """A stray EOT (and EOT/ENQ bursts) outside a transfer must be
+        ignored, not raise -- raising inside data_received is fatal to the
+        asyncio connection. Instruments emit these between sessions."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+
+        # EOT before any ENQ: must not raise, must not enter transfer state
+        self.protocol.data_received(EOT)
+        self.assertFalse(self.protocol.in_transfer_state)
+
+        # an EOT/ENQ/EOT burst must not raise either; the ENQ still
+        # establishes and gets ACKed
+        self.protocol.data_received(EOT + ENQ + EOT)
+        transport.write.assert_called_with(ACK)
+
+    def test_stray_eot_preserves_following_bytes(self):
+        """A stray EOT followed by an ENQ in the SAME read must not discard
+        the ENQ. Guards against clearing the buffer mid-dispatch."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+
+        # EOT (ignored) immediately followed by ENQ, in one recv
+        self.protocol.data_received(EOT + ENQ)
+
+        # the ENQ after the stray EOT was still processed
+        self.assertTrue(self.protocol.in_transfer_state)
+        transport.write.assert_called_with(ACK)
+
+    def test_unexpected_ack_nak_ignored(self):
+        """Unexpected ACK/NAK (we are the receiver) are ignored, not raised."""
+        transport = self.get_mock_transport()
+        self.protocol.connection_made(transport)
+        # neither of these should raise
+        self.protocol.data_received(ACK)
+        self.protocol.data_received(NAK)

--- a/src/senaite/astm/transports/astm/protocol.py
+++ b/src/senaite/astm/transports/astm/protocol.py
@@ -22,7 +22,6 @@ from senaite.astm.constants import ETX
 from senaite.astm.constants import NAK
 from senaite.astm.constants import STX
 from senaite.astm.core.instrument import find_raw_data_handler
-from senaite.astm.exceptions import InvalidState
 from senaite.astm.exceptions import NotAccepted
 from senaite.astm.transports.astm.framing import is_chunked_message
 from senaite.astm.transports.astm.framing import join
@@ -148,7 +147,14 @@ class ASTMProtocol(asyncio.Protocol):
             unit = self._pop_one_unit()
             if unit is None:
                 return
-            response = self.handle_data(unit)
+            # A single malformed/unexpected unit must never tear down the
+            # connection: log it and carry on with the next unit.
+            try:
+                response = self.handle_data(unit)
+            except Exception as exc:
+                logger.error(
+                    "Error handling unit {!r}: {!r}".format(unit, exc))
+                continue
             if response is not None:
                 logger.debug(
                     "<- Sending response: {!r}".format(response))
@@ -290,18 +296,27 @@ class ASTMProtocol(asyncio.Protocol):
 
     def on_ack(self, data):
         logger.debug("on_ack: %r", data)
-        raise NotAccepted("Server should not be ACKed.")
+        # We are the receiver and should never be ACKed. Ignore rather than
+        # raise: an exception in data_received() is fatal to the connection.
+        logger.warning("Unexpected ACK received; ignoring")
 
     def on_nak(self, data):
         logger.debug("on_nak: %r", data)
-        raise NotAccepted("Server should not be NAKed.")
+        # As above: ignore an unexpected NAK instead of tearing down the link.
+        logger.warning("Unexpected NAK received; ignoring")
 
     def on_eot(self, data):
         logger.debug("on_eot: %r", data)
 
         if not self.in_transfer_state:
-            self.close_connection()
-            raise InvalidState("Server is not ready to accept EOT message.")
+            # Stray <EOT> outside a transfer: instruments emit these between
+            # sessions (and in <EOT>/<ENQ> bursts while establishing). Ignore
+            # it and stay connected -- raising here is fatal to the asyncio
+            # connection and would force a needless reconnect. Don't call
+            # reset_session_state(): it would clear self.buffer mid-dispatch
+            # and drop any bytes that followed this EOT in the same read.
+            logger.warning("Received EOT outside a transfer; ignoring")
+            return
 
         self.cancel_timer()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up to #77 (chunked-frame reassembly). Raising inside an asyncio protocol's `data_received()` is fatal -- it drops the connection. Several ASTM handlers raised on input that instruments legitimately send, so a single stray byte forced a disconnect/reconnect even when framing was fine:

- `on_eot()` raised `InvalidState` when an `<EOT>` arrived outside a transfer, but instruments emit stray `<EOT>` (and `<EOT>`/`<ENQ>` bursts) between sessions and while establishing.
- `on_ack()`/`on_nak()` raised `NotAccepted` on any `<ACK>`/`<NAK>`; as the receiver we should ignore these.

Observed live against an Abbott ARCHITECT ci4100: after #77 made frames reassemble correctly, `<EOT>`/`<ENQ>` bursts between sessions still crashed the connection repeatedly (disconnect + reconnect churn).
  
## Current behavior before PR
  
A stray `<EOT>` outside a transfer, or any `<ACK>`/`<NAK>`, raises inside `data_received()` and tears down the connection, forcing a reconnect. One unexpected byte can interrupt an otherwise healthy link. 
  
## Desired behavior after PR is merged
  
Stray/unexpected control bytes are non-fatal: `on_eot()` outside a transfer and unexpected `on_ack()`/`on_nak()` log-and-ignore, and the unit-dispatch loop wraps `handle_data()` in `try/except` so no single byte can drop the link. The stray-`<EOT>` branch does not call `reset_session_state()` (that would clear the buffer mid-dispatch and drop bytes following the EOT in the same read). Adds tests for stray `<EOT>`, `<EOT>`/`<ENQ>` bursts, an `<EOT>`+`<ENQ>` in one read, and unexpected `<ACK>`/`<NAK>`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
